### PR TITLE
Enbable `strict` mode in Globetrotter app

### DIFF
--- a/apps/globetrotter/src/app/app.component.ts
+++ b/apps/globetrotter/src/app/app.component.ts
@@ -10,9 +10,7 @@ import { ErrorService, RouterService } from '@atocha/globetrotter/data-access';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
-  loading$ = this._routerService.state.pipe(
-    map(({ loading }) => loading)
-  );
+  loading$ = this._routerService.state.pipe(map(({ loading }) => loading));
   error$ = this._errorService.errors.pipe(map(({ global }) => !!global));
 
   constructor(

--- a/apps/globetrotter/src/app/app.component.ts
+++ b/apps/globetrotter/src/app/app.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { map } from 'rxjs/operators';
 
 import { ErrorService, RouterService } from '@atocha/globetrotter/data-access';
@@ -8,20 +7,16 @@ import { ErrorService, RouterService } from '@atocha/globetrotter/data-access';
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent implements OnInit {
-  loading$: Observable<boolean>;
-  error$: Observable<boolean>;
+export class AppComponent {
+  loading$ = this._routerService.state.pipe(
+    map(({ loading }) => loading)
+  );
+  error$ = this._errorService.errors.pipe(map(({ global }) => !!global));
 
   constructor(
     private _routerService: RouterService,
     private _errorService: ErrorService
   ) {}
-
-  ngOnInit(): void {
-    this.loading$ = this._routerService.state.pipe(
-      map(({ loading }) => loading)
-    );
-    this.error$ = this._errorService.errors.pipe(map(({ global }) => !!global));
-  }
 }

--- a/apps/globetrotter/src/stories/mock-data/default-tree-item.ts
+++ b/apps/globetrotter/src/stories/mock-data/default-tree-item.ts
@@ -1,5 +1,5 @@
-export interface IDefaultTreeItem {
+export interface DefaultTreeItem {
   id: string;
   parentId?: string;
-  children?: IDefaultTreeItem[];
+  children?: DefaultTreeItem[];
 }

--- a/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
@@ -2,22 +2,22 @@ import { Dictionary } from 'lodash';
 import { keyBy, groupBy } from 'lodash-es';
 
 import { TreeProvider } from '@atocha/globetrotter/ui';
-import { IDefaultTreeItem } from './default-tree-item';
+import { DefaultTreeItem } from './default-tree-item';
 
-export class FlatItemTreeProvider implements TreeProvider<IDefaultTreeItem> {
-  private itemsKeyedById: Dictionary<IDefaultTreeItem>;
-  private itemsGroupedByParentId: Dictionary<IDefaultTreeItem[]>;
+export class FlatItemTreeProvider implements TreeProvider<DefaultTreeItem> {
+  private itemsKeyedById: Dictionary<DefaultTreeItem>;
+  private itemsGroupedByParentId: Dictionary<DefaultTreeItem[]>;
 
-  constructor(items: IDefaultTreeItem[]) {
+  constructor(items: DefaultTreeItem[]) {
     this.itemsKeyedById = keyBy(items, 'id');
     this.itemsGroupedByParentId = groupBy(items, 'parentId');
   }
 
-  public getId(item: IDefaultTreeItem): string {
+  public getId(item: DefaultTreeItem): string {
     return item.id;
   }
 
-  public getParent(item: IDefaultTreeItem): IDefaultTreeItem | undefined {
+  public getParent(item: DefaultTreeItem): DefaultTreeItem | undefined {
     const parentId = item.parentId;
     if (parentId) {
       return this.itemsKeyedById[parentId];
@@ -25,7 +25,7 @@ export class FlatItemTreeProvider implements TreeProvider<IDefaultTreeItem> {
     return undefined;
   }
 
-  public getChildren(item: IDefaultTreeItem): IDefaultTreeItem[] {
+  public getChildren(item: DefaultTreeItem): DefaultTreeItem[] {
     return this.itemsGroupedByParentId[item.id] || [];
   }
 }

--- a/apps/globetrotter/src/stories/mock-data/flat-item.data.ts
+++ b/apps/globetrotter/src/stories/mock-data/flat-item.data.ts
@@ -1,6 +1,6 @@
-import { IDefaultTreeItem } from './default-tree-item';
+import { DefaultTreeItem } from './default-tree-item';
 
-export const FLAT_ITEMS: IDefaultTreeItem[] = [
+export const FLAT_ITEMS: DefaultTreeItem[] = [
   { id: 'Africa', parentId: undefined },
   { id: 'Southern Africa', parentId: 'Africa' },
   { id: 'Swaziland', parentId: 'Southern Africa' },

--- a/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
@@ -1,12 +1,12 @@
 import { Dictionary } from 'lodash';
 
 import { TreeProvider } from '@atocha/globetrotter/ui';
-import { IDefaultTreeItem } from './default-tree-item';
+import { DefaultTreeItem } from './default-tree-item';
 
-export class NestedItemTreeProvider implements TreeProvider<IDefaultTreeItem> {
-  private itemsKeyedById: Dictionary<IDefaultTreeItem> = {};
+export class NestedItemTreeProvider implements TreeProvider<DefaultTreeItem> {
+  private itemsKeyedById: Dictionary<DefaultTreeItem> = {};
 
-  constructor(item: IDefaultTreeItem) {
+  constructor(item: DefaultTreeItem) {
     // set itemsKeyedById recursively
     const items = [item];
     while (items.length) {
@@ -24,11 +24,11 @@ export class NestedItemTreeProvider implements TreeProvider<IDefaultTreeItem> {
     }
   }
 
-  getId(item: IDefaultTreeItem): string {
+  getId(item: DefaultTreeItem): string {
     return item.id;
   }
 
-  getParent(item: IDefaultTreeItem): IDefaultTreeItem | undefined {
+  getParent(item: DefaultTreeItem): DefaultTreeItem | undefined {
     const parentId = item.parentId;
     if (parentId) {
       return this.itemsKeyedById[parentId];
@@ -36,7 +36,7 @@ export class NestedItemTreeProvider implements TreeProvider<IDefaultTreeItem> {
     return undefined;
   }
 
-  getChildren(item: IDefaultTreeItem): IDefaultTreeItem[] {
+  getChildren(item: DefaultTreeItem): DefaultTreeItem[] {
     return item.children || [];
   }
 }

--- a/apps/globetrotter/src/stories/mock-data/nested-item.data.ts
+++ b/apps/globetrotter/src/stories/mock-data/nested-item.data.ts
@@ -1,6 +1,6 @@
-import { IDefaultTreeItem } from './default-tree-item';
+import { DefaultTreeItem } from './default-tree-item';
 
-export const NESTED_ITEM: IDefaultTreeItem = {
+export const NESTED_ITEM: DefaultTreeItem = {
   id: 'Africa',
   children: [
     {

--- a/apps/globetrotter/tsconfig.json
+++ b/apps/globetrotter/tsconfig.json
@@ -16,9 +16,7 @@
   "compilerOptions": {
     "target": "es2020",
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
+    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": true,

--- a/libs/globetrotter/data-access/src/lib/services/country.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/country.service.ts
@@ -13,7 +13,7 @@ import {
   COUNTRY_SUMMARY_NAMES,
 } from '../data/country-modifications';
 
-interface ICountryState {
+interface CountryState {
   flatCountries: Country[];
   countriesBySubregion: Dictionary<Country[]>;
   nestedCountries: Region[];
@@ -24,12 +24,12 @@ interface ICountryState {
 })
 export class CountryService implements Resolve<Observable<Country[]>> {
   private _request: Observable<Country[]> = of([]);
-  private readonly _countries = new BehaviorSubject<ICountryState>({
+  private readonly _countries = new BehaviorSubject<CountryState>({
     flatCountries: [],
     countriesBySubregion: {},
     nestedCountries: [],
   });
-  get countries(): Observable<ICountryState> {
+  get countries(): Observable<CountryState> {
     return this._countries;
   }
 

--- a/libs/globetrotter/data-access/src/lib/services/router.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/router.service.ts
@@ -15,7 +15,7 @@ import {
   distinctUntilChanged,
 } from 'rxjs/operators';
 
-interface IRouterState {
+interface RouterState {
   currentRoute: string;
   loading: boolean;
 }
@@ -24,11 +24,11 @@ interface IRouterState {
   providedIn: 'root',
 })
 export class RouterService {
-  private readonly _state = new BehaviorSubject<IRouterState>({
+  private readonly _state = new BehaviorSubject<RouterState>({
     currentRoute: '',
     loading: false,
   });
-  get state(): BehaviorSubject<IRouterState> {
+  get state(): BehaviorSubject<RouterState> {
     return this._state;
   }
 

--- a/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
+++ b/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
@@ -12,7 +12,7 @@ import {
 
 import { Country } from '@atocha/globetrotter/types';
 
-interface ITableContent {
+interface TableContent {
   header: string;
   content?: string;
   template?: TemplateRef<unknown>;
@@ -32,7 +32,7 @@ export class ExploreCountryComponent implements OnChanges, AfterViewInit {
   @ViewChild('language') languageTemplate: TemplateRef<unknown> | undefined;
   @ViewChild('currency') currencyTemplate: TemplateRef<unknown> | undefined;
   @ViewChild('list') listTemplate: TemplateRef<unknown> | undefined;
-  tableData: ITableContent[] = [];
+  tableData: TableContent[] = [];
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 

--- a/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.ts
+++ b/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.ts
@@ -4,7 +4,7 @@ import { AnimatedComponent } from '@atocha/core/ui';
 import { positionAnimation } from '@atocha/globetrotter/ui';
 import { Route } from '@atocha/globetrotter/types';
 
-interface INavigationLink {
+interface NavigationLink {
   name: string;
   route: string;
   icon?: string;
@@ -20,13 +20,13 @@ interface INavigationLink {
 })
 export class NavigationComponent extends AnimatedComponent {
   position = 'navigation';
-  home: INavigationLink = {
+  home: NavigationLink = {
     name: 'Home',
     icon: 'Globetrotter',
     route: Route.home,
     exactPathMatch: true,
   };
-  links: INavigationLink[] = [
+  links: NavigationLink[] = [
     {
       name: 'Explore',
       route: Route.explore,

--- a/libs/globetrotter/ui/src/lib/list-details/list-details.component.ts
+++ b/libs/globetrotter/ui/src/lib/list-details/list-details.component.ts
@@ -19,7 +19,7 @@ import {
 
 import { InputComponent } from '../input/input.component';
 
-export interface IListDetailsStyles {
+export interface ListDetailsStyles {
   offsetTop: string;
   gap: string;
 }
@@ -36,7 +36,7 @@ export class ListDetailsComponent<T>
   @Input() items: T[] = [];
   @Input() listItemTemplate: TemplateRef<unknown> | undefined;
   @Input() detailsTemplate: TemplateRef<unknown> | undefined;
-  @Input() styles: IListDetailsStyles = {
+  @Input() styles: ListDetailsStyles = {
     offsetTop: '0px',
     gap: '12px',
   };


### PR DESCRIPTION
1. Turns on `strict` mode and configures other tsconfig.json settings to match those of Nx-generated projects
2. Turns on `OnPush` change detection in feature-shell and app components
3. Removes `I` prefix from all interfaces across monorepo