### PR TITLE
`Selection` refactoring

### DIFF
--- a/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
@@ -1,12 +1,11 @@
-import { Dictionary } from 'lodash';
 import { keyBy, groupBy } from 'lodash-es';
 
-import { TreeProvider } from '@atocha/globetrotter/ui';
+import { TreeProvider } from '@atocha/globetrotter/types';
 import { DefaultTreeItem } from './default-tree-item';
 
 export class FlatItemTreeProvider implements TreeProvider<DefaultTreeItem> {
-  private itemsKeyedById: Dictionary<DefaultTreeItem>;
-  private itemsGroupedByParentId: Dictionary<DefaultTreeItem[]>;
+  private itemsKeyedById: Record<string, DefaultTreeItem>;
+  private itemsGroupedByParentId: Record<string, DefaultTreeItem[]>;
 
   constructor(items: DefaultTreeItem[]) {
     this.itemsKeyedById = keyBy(items, 'id');

--- a/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/flat-item-tree-provider.class.ts
@@ -1,30 +1,30 @@
 import { keyBy, groupBy } from 'lodash-es';
 
-import { TreeProvider } from '@atocha/globetrotter/types';
+import { TreeProvider } from '@atocha/globetrotter/ui';
 import { DefaultTreeItem } from './default-tree-item';
 
 export class FlatItemTreeProvider implements TreeProvider<DefaultTreeItem> {
-  private itemsKeyedById: Record<string, DefaultTreeItem>;
-  private itemsGroupedByParentId: Record<string, DefaultTreeItem[]>;
+  private _itemsKeyedById: Record<string, DefaultTreeItem>;
+  private _itemsGroupedByParentId: Record<string, DefaultTreeItem[]>;
 
   constructor(items: DefaultTreeItem[]) {
-    this.itemsKeyedById = keyBy(items, 'id');
-    this.itemsGroupedByParentId = groupBy(items, 'parentId');
+    this._itemsKeyedById = keyBy(items, 'id');
+    this._itemsGroupedByParentId = groupBy(items, 'parentId');
   }
 
-  public getId(item: DefaultTreeItem): string {
+  getId(item: DefaultTreeItem): string {
     return item.id;
   }
 
-  public getParent(item: DefaultTreeItem): DefaultTreeItem | undefined {
+  getParent(item: DefaultTreeItem): DefaultTreeItem | undefined {
     const parentId = item.parentId;
     if (parentId) {
-      return this.itemsKeyedById[parentId];
+      return this._itemsKeyedById[parentId];
     }
     return undefined;
   }
 
-  public getChildren(item: DefaultTreeItem): DefaultTreeItem[] {
-    return this.itemsGroupedByParentId[item.id] || [];
+  getChildren(item: DefaultTreeItem): DefaultTreeItem[] {
+    return this._itemsGroupedByParentId[item.id] || [];
   }
 }

--- a/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
@@ -1,10 +1,8 @@
-import { Dictionary } from 'lodash';
-
-import { TreeProvider } from '@atocha/globetrotter/ui';
+import { TreeProvider } from '@atocha/globetrotter/types';
 import { DefaultTreeItem } from './default-tree-item';
 
 export class NestedItemTreeProvider implements TreeProvider<DefaultTreeItem> {
-  private itemsKeyedById: Dictionary<DefaultTreeItem> = {};
+  private itemsKeyedById: Record<string, DefaultTreeItem> = {};
 
   constructor(item: DefaultTreeItem) {
     // set itemsKeyedById recursively

--- a/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
+++ b/apps/globetrotter/src/stories/mock-data/nested-item-tree-provider.class.ts
@@ -1,8 +1,8 @@
-import { TreeProvider } from '@atocha/globetrotter/types';
+import { TreeProvider } from '@atocha/globetrotter/ui';
 import { DefaultTreeItem } from './default-tree-item';
 
 export class NestedItemTreeProvider implements TreeProvider<DefaultTreeItem> {
-  private itemsKeyedById: Record<string, DefaultTreeItem> = {};
+  private _itemsKeyedById: Record<string, DefaultTreeItem> = {};
 
   constructor(item: DefaultTreeItem) {
     // set itemsKeyedById recursively
@@ -12,7 +12,7 @@ export class NestedItemTreeProvider implements TreeProvider<DefaultTreeItem> {
       if (currentItem) {
         const currentItemId = this.getId(currentItem);
         const currentItemChildren = this.getChildren(currentItem);
-        this.itemsKeyedById[currentItemId] = currentItem;
+        this._itemsKeyedById[currentItemId] = currentItem;
         if (currentItemChildren.length) {
           currentItemChildren.forEach((child) => {
             items.push(child);
@@ -29,7 +29,7 @@ export class NestedItemTreeProvider implements TreeProvider<DefaultTreeItem> {
   getParent(item: DefaultTreeItem): DefaultTreeItem | undefined {
     const parentId = item.parentId;
     if (parentId) {
-      return this.itemsKeyedById[parentId];
+      return this._itemsKeyedById[parentId];
     }
     return undefined;
   }

--- a/libs/globetrotter/data-access/jest.config.ts
+++ b/libs/globetrotter/data-access/jest.config.ts
@@ -19,7 +19,7 @@ export default {
     'jest-preset-angular/build/serializers/ng-snapshot',
     'jest-preset-angular/build/serializers/html-comment',
   ],
-  "moduleNameMapper": {
-    "^lodash-es$": "lodash"
-  }
+  moduleNameMapper: {
+    '^lodash-es$': 'lodash',
+  },
 };

--- a/libs/globetrotter/data-access/jest.config.ts
+++ b/libs/globetrotter/data-access/jest.config.ts
@@ -19,4 +19,7 @@ export default {
     'jest-preset-angular/build/serializers/ng-snapshot',
     'jest-preset-angular/build/serializers/html-comment',
   ],
+  "moduleNameMapper": {
+    "^lodash-es$": "lodash"
+  }
 };

--- a/libs/globetrotter/data-access/src/index.ts
+++ b/libs/globetrotter/data-access/src/index.ts
@@ -1,5 +1,3 @@
-export * from './lib/data/places-tree-provider.class';
-
 export * from './lib/services/api.service';
 export * from './lib/services/country.service';
 export * from './lib/services/error.service';

--- a/libs/globetrotter/data-access/src/lib/data/country-modifications.ts
+++ b/libs/globetrotter/data-access/src/lib/data/country-modifications.ts
@@ -1,8 +1,6 @@
 // Modifications to REST Countries API names for use in Globetrotter
 
-import { Dictionary } from 'lodash';
-
-export const COUNTRY_APP_NAMES: Dictionary<string> = {
+export const COUNTRY_APP_NAMES: Record<string, string> = {
   "Côte d'Ivoire": 'Ivory Coast',
   "Korea (Democratic People's Republic of)": 'North Korea',
   'Korea (Republic of)': 'South Korea',
@@ -10,6 +8,6 @@ export const COUNTRY_APP_NAMES: Dictionary<string> = {
   'Macedonia (the former Yugoslav Republic of)': 'North Macedonia',
 };
 
-export const COUNTRY_SUMMARY_NAMES: Dictionary<string> = {
+export const COUNTRY_SUMMARY_NAMES: Record<string, string> = {
   Georgia: 'Georgia country',
 };

--- a/libs/globetrotter/data-access/src/lib/data/country-statuses.ts
+++ b/libs/globetrotter/data-access/src/lib/data/country-statuses.ts
@@ -1,8 +1,6 @@
-import { Dictionary } from 'lodash';
-
 // List of UN member/observer states
 
-export const COUNTRY_STATUSES: Dictionary<boolean> = {
+export const COUNTRY_STATUSES: Record<string, boolean> = {
   Afghanistan: true,
   'Åland Islands': false,
   Albania: true,

--- a/libs/globetrotter/data-access/src/lib/data/places-tree-provider.class.ts
+++ b/libs/globetrotter/data-access/src/lib/data/places-tree-provider.class.ts
@@ -1,5 +1,3 @@
-import { Dictionary } from 'lodash';
-
 import {
   Place,
   Region,
@@ -8,7 +6,7 @@ import {
 } from '@atocha/globetrotter/types';
 
 export class PlacesTreeProvider implements TreeProvider<Place> {
-  private _placesById: Dictionary<Place> = {};
+  private _placesById: Record<string, Place> = {};
 
   constructor(place: Place) {
     // set placesKeyedById recursively

--- a/libs/globetrotter/data-access/src/lib/services/country.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/country.service.ts
@@ -60,7 +60,7 @@ export class CountryService implements Resolve<Observable<Country[]>> {
       map(({ countriesBySubregion }) => {
         const quantity = selection.quantity || undefined;
         const countries = reduce(
-          selection.countries,
+          selection.places,
           (accum, checkboxState, placeName) => {
             if (
               checkboxState === 'checked' &&

--- a/libs/globetrotter/data-access/src/lib/services/country.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/country.service.ts
@@ -3,7 +3,6 @@ import { Resolve } from '@angular/router';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { groupBy, reduce, shuffle, map as _map } from 'lodash-es';
-import { Dictionary } from 'lodash';
 
 import { Country, Region, Selection } from '@atocha/globetrotter/types';
 import { ApiService } from './api.service';
@@ -15,7 +14,7 @@ import {
 
 interface CountryState {
   flatCountries: Country[];
-  countriesBySubregion: Dictionary<Country[]>;
+  countriesBySubregion: Record<string, Country[]>;
   nestedCountries: Region[];
 }
 
@@ -95,8 +94,8 @@ export class CountryService implements Resolve<Observable<Country[]>> {
   }
 
   private _groupSubregionsByRegion(
-    countriesBySubregion: Dictionary<Country[]>
-  ): Dictionary<string[]> {
+    countriesBySubregion: Record<string, Country[]>
+  ): Record<string, string[]> {
     return reduce(
       countriesBySubregion,
       (accum, countries, subregion) => {
@@ -114,13 +113,13 @@ export class CountryService implements Resolve<Observable<Country[]>> {
           };
         }
       },
-      {} as Dictionary<string[]>
+      {} as Record<string, string[]>
     );
   }
 
   private _formatNestedCountries(
-    countriesBySubregion: Dictionary<Country[]>,
-    subregionsByRegion: Dictionary<string[]>
+    countriesBySubregion: Record<string, Country[]>,
+    subregionsByRegion: Record<string, string[]>
   ): Region[] {
     return reduce(
       subregionsByRegion,

--- a/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
@@ -1,21 +1,53 @@
-import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { SelectService } from './select.service';
+import { QuizType } from '@atocha/globetrotter/types';
 
 describe('SelectService', () => {
   let service: SelectService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        { provide: HttpClient, useClass: {} },
-      ],
+      imports: [HttpClientTestingModule],
     });
     service = TestBed.inject(SelectService);
   });
 
-  it('should be created', () => {
+  it('renders', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('maps a selection to selection query params', () => {
+    expect(service.mapSelectionToQueryParams({
+      type: QuizType.flagsCountries,
+      quantity: 3,
+      places: {
+        Asia: 'indeterminate',
+        'Southern Asia': 'checked',
+        'Western Asia': 'checked',
+      },
+    })).toEqual({
+      type: "1",
+      quantity: "3",
+      places: "Asia_i,Southern Asia_c,Western Asia_c",
+    });
+  });
+
+  it('maps selection query params to a selection', () => {
+    expect(service.mapQueryParamsToSelection({
+      type: '2',
+      quantity: '7',
+      places: 'Oceania_i,Melanesia_c,Micronesia_c,Polynesia_c',
+    })).toEqual({
+      type: QuizType.capitalsCountries,
+      quantity: 7,
+      places: {
+        Oceania: 'indeterminate',
+        Melanesia: 'checked',
+        Micronesia: 'checked',
+        Polynesia: 'checked',
+      },
+    });
   });
 });

--- a/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
@@ -12,29 +12,31 @@ describe('SelectService', () => {
     countries: new BehaviorSubject({
       nestedCountries: [
         {
-          "name": "Africa",
-          "subregions": [
+          name: 'Africa',
+          subregions: [
             {
-              "name": "Northern Africa",
-              "region": "Africa",
+              name: 'Northern Africa',
+              region: 'Africa',
             },
             {
-              "name": "Western Africa",
-              "region": "Africa",
+              name: 'Western Africa',
+              region: 'Africa',
             },
-          ]
-        }
+          ],
+        },
       ],
-    })
+    }),
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [{
-        provide: CountryService,
-        useValue: mockCountryService,
-      }],
+      providers: [
+        {
+          provide: CountryService,
+          useValue: mockCountryService,
+        },
+      ],
     });
     service = TestBed.inject(SelectService);
   });
@@ -56,27 +58,31 @@ describe('SelectService', () => {
   });
 
   it('maps selection to selection query params', () => {
-    expect(service.mapSelectionToQueryParams({
-      type: QuizType.flagsCountries,
-      quantity: 3,
-      places: {
-        Asia: 'indeterminate',
-        'Southern Asia': 'checked',
-        'Western Asia': 'checked',
-      },
-    })).toEqual({
-      type: "1",
-      quantity: "3",
-      places: "Asia_i,Southern Asia_c,Western Asia_c",
+    expect(
+      service.mapSelectionToQueryParams({
+        type: QuizType.flagsCountries,
+        quantity: 3,
+        places: {
+          Asia: 'indeterminate',
+          'Southern Asia': 'checked',
+          'Western Asia': 'checked',
+        },
+      })
+    ).toEqual({
+      type: '1',
+      quantity: '3',
+      places: 'Asia_i,Southern Asia_c,Western Asia_c',
     });
   });
 
   it('maps selection query params to selection', () => {
-    expect(service.mapQueryParamsToSelection({
-      type: '2',
-      quantity: '7',
-      places: 'Oceania_i,Melanesia_c,Micronesia_c,Polynesia_c',
-    })).toEqual({
+    expect(
+      service.mapQueryParamsToSelection({
+        type: '2',
+        quantity: '7',
+        places: 'Oceania_i,Melanesia_c,Micronesia_c,Polynesia_c',
+      })
+    ).toEqual({
       type: QuizType.capitalsCountries,
       quantity: 7,
       places: {

--- a/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+
+import { SelectService } from './select.service';
+
+describe('SelectService', () => {
+  let service: SelectService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useClass: {} },
+      ],
+    });
+    service = TestBed.inject(SelectService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.spec.ts
@@ -1,15 +1,40 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BehaviorSubject } from 'rxjs';
 
-import { SelectService } from './select.service';
 import { QuizType } from '@atocha/globetrotter/types';
+import { CountryService } from './country.service';
+import { SelectService } from './select.service';
 
 describe('SelectService', () => {
   let service: SelectService;
+  const mockCountryService = {
+    countries: new BehaviorSubject({
+      nestedCountries: [
+        {
+          "name": "Africa",
+          "subregions": [
+            {
+              "name": "Northern Africa",
+              "region": "Africa",
+            },
+            {
+              "name": "Western Africa",
+              "region": "Africa",
+            },
+          ]
+        }
+      ],
+    })
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
+      providers: [{
+        provide: CountryService,
+        useValue: mockCountryService,
+      }],
     });
     service = TestBed.inject(SelectService);
   });
@@ -18,7 +43,19 @@ describe('SelectService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('maps a selection to selection query params', () => {
+  it('contains correct default selection', () => {
+    expect(service.selection.value).toEqual({
+      type: 1,
+      quantity: 5,
+      places: {
+        Africa: 'checked',
+        'Northern Africa': 'checked',
+        'Western Africa': 'checked',
+      },
+    });
+  });
+
+  it('maps selection to selection query params', () => {
     expect(service.mapSelectionToQueryParams({
       type: QuizType.flagsCountries,
       quantity: 3,
@@ -34,7 +71,7 @@ describe('SelectService', () => {
     });
   });
 
-  it('maps selection query params to a selection', () => {
+  it('maps selection query params to selection', () => {
     expect(service.mapQueryParamsToSelection({
       type: '2',
       quantity: '7',

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -8,8 +8,8 @@ import {
   QuizType,
   Selection,
   SelectionParams,
-  CheckboxState,
   PlaceSelection,
+  PlaceSelectionState,
 } from '@atocha/globetrotter/types';
 import { CountryService } from './country.service';
 
@@ -17,7 +17,7 @@ import { CountryService } from './country.service';
   providedIn: 'root',
 })
 export class SelectService {
-  private readonly _paramDict: Record<string, string> = {
+  private readonly _paramDict: Record<PlaceSelectionState, string> = {
     checked: '_c',
     indeterminate: '_i',
   };
@@ -78,7 +78,7 @@ export class SelectService {
     const quantity = selection.quantity.toString();
     const places = _map(
       selection.places,
-      (value: CheckboxState, key) => key + this._paramDict[value]
+      (value, key) => key + this._paramDict[value]
     ).join(',');
     return {
       type,

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -31,7 +31,7 @@ export class SelectService {
     this._selection = new BehaviorSubject<Selection>({
       type: QuizType.flagsCountries,
       quantity: 5,
-      countries: {},
+      places: {},
     });
     this._countryService.countries
       .pipe(
@@ -39,13 +39,12 @@ export class SelectService {
         map(({ nestedCountries }) => nestedCountries)
       )
       .subscribe((regions) => {
-        const countries = this._mapPlacesToCheckboxStates(regions);
-        this.updateCountries(countries);
+        const checkboxStates = this._mapPlacesToCheckboxStates(regions);
+        this.updatePlaces(checkboxStates);
       });
   }
 
   updateSelection(selection: Selection): void {
-    console.log(selection);
     this._selection.next(selection);
   }
 
@@ -67,11 +66,11 @@ export class SelectService {
       .subscribe((selection) => this._selection.next(selection));
   }
 
-  updateCountries(countries: CheckboxStates): void {
+  updatePlaces(places: CheckboxStates): void {
     this._selection
       .pipe(
         first(),
-        map((selection) => ({ ...selection, countries }))
+        map((selection) => ({ ...selection, places }))
       )
       .subscribe((selection) => this._selection.next(selection));
   }
@@ -79,25 +78,25 @@ export class SelectService {
   mapSelectionToQueryParams(selection: Selection): SelectionParams {
     const type = selection.type.toString();
     const quantity = selection.quantity.toString();
-    const selectedCountries = omitBy(
-      selection.countries,
+    const selectedPlaces = omitBy(
+      selection.places,
       (value) => value === 'unchecked'
     );
-    const countries = _map(
-      selectedCountries,
+    const places = _map(
+      selectedPlaces,
       (value: CheckboxState, key) => key + this._paramDict[value]
     ).join(',');
     return {
       type,
       quantity,
-      countries,
+      places,
     };
   }
 
   mapQueryParamsToSelection(queryParams: SelectionParams): Selection {
     const type = parseInt(queryParams.type, 10) as QuizType;
     const quantity = parseInt(queryParams.quantity, 10);
-    const countries = queryParams.countries
+    const places = queryParams.places
       .split(',')
       .reduce((accum, current) => {
         if (current.includes(this._paramDict.checked)) {
@@ -116,7 +115,7 @@ export class SelectService {
     return {
       type,
       quantity,
-      countries,
+      places,
     };
   }
 

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -39,12 +39,13 @@ export class SelectService {
         map(({ nestedCountries }) => nestedCountries)
       )
       .subscribe((regions) => {
-        const countries = this._mapCountriesToCheckboxStates(regions);
+        const countries = this._mapPlacesToCheckboxStates(regions);
         this.updateCountries(countries);
       });
   }
 
   updateSelection(selection: Selection): void {
+    console.log(selection);
     this._selection.next(selection);
   }
 
@@ -119,13 +120,16 @@ export class SelectService {
     };
   }
 
-  private _mapCountriesToCheckboxStates(countries: Region[]): CheckboxStates {
-    return countries.reduce((accum, region) => {
-      accum[region.name] = 'checked';
-      region.subregions.forEach((subregion) => {
-        accum[subregion?.name] = 'checked';
-      });
-      return accum;
-    }, {} as CheckboxStates);
+  private _mapPlacesToCheckboxStates(regions: Region[]): CheckboxStates {
+    const checkboxStates: CheckboxStates = {};
+
+    for (const { name, subregions } of regions) {
+      checkboxStates[name] = 'checked';
+      for (const { name } of subregions) {
+        checkboxStates[name] = 'checked';
+      }
+    }
+
+    return checkboxStates;
   }
 }

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { first, map } from 'rxjs/operators';
-import { replace } from 'lodash-es';
 
 import {
   Region,
@@ -94,14 +93,10 @@ export class SelectService {
       .split(',')
       .reduce((accum, current) => {
         if (current.includes(this._paramDict['checked'])) {
-          const updatedKey = replace(current, this._paramDict['checked'], '');
+          const updatedKey = current.replace(this._paramDict['checked'], '');
           accum[updatedKey] = 'checked';
         } else if (current.includes(this._paramDict['indeterminate'])) {
-          const updatedKey = replace(
-            current,
-            this._paramDict['indeterminate'],
-            ''
-          );
+          const updatedKey = current.replace(this._paramDict['indeterminate'], '');
           accum[updatedKey] = 'indeterminate';
         }
         return accum;

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -75,8 +75,7 @@ export class SelectService {
   mapSelectionToQueryParams(selection: Selection): SelectionParams {
     const type = selection.type.toString();
     const quantity = selection.quantity.toString();
-    const places = Object
-      .entries(selection.places)
+    const places = Object.entries(selection.places)
       .map(([place, state]) => place + this._paramDict[state])
       .join(',');
     return {
@@ -89,18 +88,19 @@ export class SelectService {
   mapQueryParamsToSelection(queryParams: SelectionParams): Selection {
     const type = parseInt(queryParams.type, 10) as QuizType;
     const quantity = parseInt(queryParams.quantity, 10);
-    const places = queryParams.places
-      .split(',')
-      .reduce((accum, current) => {
-        if (current.includes(this._paramDict['checked'])) {
-          const updatedKey = current.replace(this._paramDict['checked'], '');
-          accum[updatedKey] = 'checked';
-        } else if (current.includes(this._paramDict['indeterminate'])) {
-          const updatedKey = current.replace(this._paramDict['indeterminate'], '');
-          accum[updatedKey] = 'indeterminate';
-        }
-        return accum;
-      }, {} as PlaceSelection);
+    const places = queryParams.places.split(',').reduce((accum, current) => {
+      if (current.includes(this._paramDict['checked'])) {
+        const updatedKey = current.replace(this._paramDict['checked'], '');
+        accum[updatedKey] = 'checked';
+      } else if (current.includes(this._paramDict['indeterminate'])) {
+        const updatedKey = current.replace(
+          this._paramDict['indeterminate'],
+          ''
+        );
+        accum[updatedKey] = 'indeterminate';
+      }
+      return accum;
+    }, {} as PlaceSelection);
     return {
       type,
       quantity,

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { first, map } from 'rxjs/operators';
-import { replace, map as _map } from 'lodash-es';
+import { replace } from 'lodash-es';
 
 import {
   Region,
@@ -76,10 +76,10 @@ export class SelectService {
   mapSelectionToQueryParams(selection: Selection): SelectionParams {
     const type = selection.type.toString();
     const quantity = selection.quantity.toString();
-    const places = _map(
-      selection.places,
-      (value, key) => key + this._paramDict[value]
-    ).join(',');
+    const places = Object
+      .entries(selection.places)
+      .map(([place, state]) => place + this._paramDict[state])
+      .join(',');
     return {
       type,
       quantity,

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -38,7 +38,7 @@ export class SelectService {
         map(({ nestedCountries }) => nestedCountries)
       )
       .subscribe((regions) => {
-        this.updatePlaces(this._mapToPlaceSelection(regions));
+        this.updatePlaces(this._mapRegionsToPlaceSelection(regions));
       });
   }
 
@@ -113,7 +113,7 @@ export class SelectService {
     };
   }
 
-  private _mapToPlaceSelection(regions: Region[]): PlaceSelection {
+  private _mapRegionsToPlaceSelection(regions: Region[]): PlaceSelection {
     const placeSelection: PlaceSelection = {};
 
     for (const { name, subregions } of regions) {

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
@@ -15,14 +15,14 @@ import { QuizType } from '@atocha/globetrotter/types';
   animations: [fadeInAnimation, staggerAnimation],
 })
 export class QuizCardsComponent {
-  private _quizType$ = this.quizService.quiz.pipe(
+  private _quizType$ = this._quizService.quiz.pipe(
     map((quiz) => quiz?.type ?? QuizType.flagsCountries)
   );
-  private _countries$ = this.quizService.quiz.pipe(
+  private _countries$ = this._quizService.quiz.pipe(
     first(),
     map((quiz) => shuffle(quiz?.countries ?? []))
   );
-  private _currentCountry$ = this.quizService.quiz.pipe(
+  private _currentCountry$ = this._quizService.quiz.pipe(
     map((quiz) => quiz?.countries[0] ?? undefined)
   );
   vm$ = combineLatest([
@@ -38,7 +38,7 @@ export class QuizCardsComponent {
   );
   canFlipCards = true;
 
-  constructor(private quizService: QuizService) {}
+  constructor(private _quizService: QuizService) {}
 
   onFlip(cardFlipped: boolean): void {
     this.canFlipCards = !cardFlipped;

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz.component.ts
@@ -24,7 +24,7 @@ export class QuizComponent implements OnInit {
       const params: SelectionParams = {
         type: queryParams.get('type') || '',
         quantity: queryParams.get('quantity') || '',
-        countries: queryParams.get('countries') || '',
+        places: queryParams.get('places') || '',
       };
       const selection = this._selectService.mapQueryParamsToSelection(params);
       this._selectService.updateSelection(selection);

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/places-tree-provider.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/places-tree-provider.ts
@@ -1,8 +1,4 @@
-import {
-  Place,
-  Region,
-  Subregion,
-} from '@atocha/globetrotter/types';
+import { Place, Region, Subregion } from '@atocha/globetrotter/types';
 import { TreeProvider } from '@atocha/globetrotter/ui';
 
 export class PlacesTreeProvider implements TreeProvider<Place> {

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/places-tree-provider.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/places-tree-provider.ts
@@ -2,8 +2,8 @@ import {
   Place,
   Region,
   Subregion,
-  TreeProvider,
 } from '@atocha/globetrotter/types';
+import { TreeProvider } from '@atocha/globetrotter/ui';
 
 export class PlacesTreeProvider implements TreeProvider<Place> {
   private _placesById: Record<string, Place> = {};

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -9,14 +9,10 @@ import {
   shareReplay,
 } from 'rxjs/operators';
 
-import {
-  CountryService,
-  isSubregion,
-  PlacesTreeProvider,
-  SelectService,
-} from '@atocha/globetrotter/data-access';
+import { CountryService, SelectService } from '@atocha/globetrotter/data-access';
 import { Place, PlaceSelection } from '@atocha/globetrotter/types';
 import { CheckboxStates } from '@atocha/globetrotter/ui';
+import { PlacesTreeProvider, isSubregion } from './places-tree-provider';
 
 @Component({
   selector: 'app-select-countries',

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -9,7 +9,10 @@ import {
   shareReplay,
 } from 'rxjs/operators';
 
-import { CountryService, SelectService } from '@atocha/globetrotter/data-access';
+import {
+  CountryService,
+  SelectService,
+} from '@atocha/globetrotter/data-access';
 import { Place, PlaceSelection } from '@atocha/globetrotter/types';
 import { CheckboxStates } from '@atocha/globetrotter/ui';
 import { PlacesTreeProvider, isSubregion } from './places-tree-provider';

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -39,18 +39,15 @@ export class SelectCountriesComponent {
     }),
     map((regions) =>
       regions.map((region) => {
-        const treeProvider = new PlacesTreeProvider(region);
         const selectedSubject = new BehaviorSubject<number>(0);
         const totalSubject = new BehaviorSubject<number>(0);
-        const selected$ = selectedSubject.pipe(distinctUntilChanged());
-        const total$ = totalSubject.pipe(distinctUntilChanged());
         return {
           region: region as Place,
-          treeProvider,
+          treeProvider: new PlacesTreeProvider(region),
           selectedSubject,
           totalSubject,
-          selected$,
-          total$,
+          selected$: selectedSubject.pipe(distinctUntilChanged()),
+          total$: totalSubject.pipe(distinctUntilChanged()),
         };
       })
     ),

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -9,13 +9,14 @@ import {
   shareReplay,
 } from 'rxjs/operators';
 
-import { CheckboxStates, Place, PlaceSelection } from '@atocha/globetrotter/types';
 import {
   CountryService,
   isSubregion,
   PlacesTreeProvider,
   SelectService,
 } from '@atocha/globetrotter/data-access';
+import { Place, PlaceSelection } from '@atocha/globetrotter/types';
+import { CheckboxStates } from '@atocha/globetrotter/ui';
 
 @Component({
   selector: 'app-select-countries',

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -98,7 +98,7 @@ export class SelectCountriesComponent {
   ) {}
 
   onCountriesChange(state: CheckboxStates): void {
-    this._selectService.updatePlaces(this._sanitizeState(state));
+    this._selectService.updatePlaces(this._transformState(state));
   }
 
   onSelectAll(): void {
@@ -116,17 +116,17 @@ export class SelectCountriesComponent {
     return 0;
   }
 
-  private _sanitizeState(state: CheckboxStates): PlaceSelection {
-    const sanitizedState: PlaceSelection = {};
+  private _transformState(state: CheckboxStates): PlaceSelection {
+    const placeSelection: PlaceSelection = {};
 
     for (const [place, checkboxState] of Object.entries(state)) {
       if (checkboxState === 'checked') {
-        sanitizedState[place] = 'checked';
+        placeSelection[place] = 'checked';
       } else if (checkboxState === 'indeterminate') {
-        sanitizedState[place] = 'indeterminate';
+        placeSelection[place] = 'indeterminate';
       }
     }
 
-    return sanitizedState;
+    return placeSelection;
   }
 }

--- a/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-countries/select-countries.component.ts
@@ -26,7 +26,7 @@ import {
 export class SelectCountriesComponent {
   private fullySelectedState: CheckboxStates = {};
   private _checkboxStates$ = this._selectService.selection.pipe(
-    map(({ countries }) => countries)
+    map(({ places }) => places)
   );
   private _regionData$ = this._countryService.countries.pipe(
     first(),
@@ -101,15 +101,15 @@ export class SelectCountriesComponent {
   ) {}
 
   onCountriesChange(state: CheckboxStates): void {
-    this._selectService.updateCountries(state);
+    this._selectService.updatePlaces(state);
   }
 
   onSelectAll(): void {
-    this._selectService.updateCountries(this.fullySelectedState);
+    this._selectService.updatePlaces(this.fullySelectedState);
   }
 
   onClearAll(): void {
-    this._selectService.updateCountries({});
+    this._selectService.updatePlaces({});
   }
 
   getNumberOfCountries(item: Place): number {

--- a/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
@@ -5,7 +5,7 @@ import { map, tap, distinctUntilChanged } from 'rxjs/operators';
 import { pickBy } from 'lodash-es';
 
 import { fadeInAnimation } from '@atocha/globetrotter/ui';
-import { Selection, SelectionParams, Route } from '@atocha/globetrotter/types';
+import { Selection, Route } from '@atocha/globetrotter/types';
 import {
   CountryService,
   SelectService,
@@ -19,7 +19,6 @@ import {
   animations: [fadeInAnimation],
 })
 export class SelectComponent {
-  private _queryParams: SelectionParams | undefined;
   private _selection: Selection | undefined;
   private _selection$ = this._selectService.selection.pipe(
     tap((selection) => (this._selection = selection))
@@ -84,11 +83,9 @@ export class SelectComponent {
       return;
     }
 
-    this._queryParams = this._selectService.mapSelectionToQueryParams(
-      this._selection
-    );
+    const queryParams = this._selectService.mapSelectionToQueryParams(this._selection);
     await this._router.navigate([`${Route.learn}/${Route.quiz}`], {
-      queryParams: this._queryParams,
+      queryParams,
     });
   }
 }

--- a/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
@@ -34,7 +34,7 @@ export class SelectComponent {
   ]).pipe(
     map(([subregions, selection]) => {
       const selectedCountries = pickBy(
-        selection.countries,
+        selection.places,
         (value) => value === 'checked'
       );
       return Object.keys(selectedCountries).reduce(

--- a/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select.component.ts
@@ -83,7 +83,9 @@ export class SelectComponent {
       return;
     }
 
-    const queryParams = this._selectService.mapSelectionToQueryParams(this._selection);
+    const queryParams = this._selectService.mapSelectionToQueryParams(
+      this._selection
+    );
     await this._router.navigate([`${Route.learn}/${Route.quiz}`], {
       queryParams,
     });

--- a/libs/globetrotter/types/src/index.ts
+++ b/libs/globetrotter/types/src/index.ts
@@ -9,4 +9,3 @@ export * from './lib/quiz-type.enum';
 export * from './lib/quiz.interface';
 export * from './lib/route.enum';
 export * from './lib/selection.interface';
-export * from './lib/tree-provider.interface';

--- a/libs/globetrotter/types/src/index.ts
+++ b/libs/globetrotter/types/src/index.ts
@@ -4,7 +4,6 @@ export * from './lib/domain/region.interface';
 export * from './lib/domain/subregion.interface';
 export * from './lib/domain/summary.interface';
 
-export * from './lib/checkbox';
 export * from './lib/duration.enum';
 export * from './lib/quiz-type.enum';
 export * from './lib/quiz.interface';

--- a/libs/globetrotter/types/src/lib/checkbox.ts
+++ b/libs/globetrotter/types/src/lib/checkbox.ts
@@ -1,4 +1,2 @@
-import { Dictionary } from 'lodash';
-
 export type CheckboxState = 'checked' | 'unchecked' | 'indeterminate';
-export type CheckboxStates = Dictionary<CheckboxState>;
+export type CheckboxStates = Record<string, CheckboxState>;

--- a/libs/globetrotter/types/src/lib/checkbox.ts
+++ b/libs/globetrotter/types/src/lib/checkbox.ts
@@ -1,2 +1,0 @@
-export type CheckboxState = 'checked' | 'unchecked' | 'indeterminate';
-export type CheckboxStates = Record<string, CheckboxState>;

--- a/libs/globetrotter/types/src/lib/selection.interface.ts
+++ b/libs/globetrotter/types/src/lib/selection.interface.ts
@@ -4,11 +4,11 @@ import { QuizType } from './quiz-type.enum';
 export interface Selection {
   type: QuizType;
   quantity: number;
-  countries: CheckboxStates;
+  places: CheckboxStates;
 }
 
 export interface SelectionParams {
   type: string;
   quantity: string;
-  countries: string;
+  places: string;
 }

--- a/libs/globetrotter/types/src/lib/selection.interface.ts
+++ b/libs/globetrotter/types/src/lib/selection.interface.ts
@@ -12,4 +12,5 @@ export interface SelectionParams {
   places: string;
 }
 
-export type PlaceSelection = Record<string, 'checked' | 'indeterminate'>;
+export type PlaceSelection = Record<string, PlaceSelectionState>;
+export type PlaceSelectionState = 'checked' | 'indeterminate';

--- a/libs/globetrotter/types/src/lib/selection.interface.ts
+++ b/libs/globetrotter/types/src/lib/selection.interface.ts
@@ -1,10 +1,9 @@
-import { CheckboxStates } from './checkbox';
 import { QuizType } from './quiz-type.enum';
 
 export interface Selection {
   type: QuizType;
   quantity: number;
-  places: CheckboxStates;
+  places: PlaceSelection;
 }
 
 export interface SelectionParams {
@@ -12,3 +11,5 @@ export interface SelectionParams {
   quantity: string;
   places: string;
 }
+
+export type PlaceSelection = Record<string, 'checked' | 'indeterminate'>;

--- a/libs/globetrotter/types/src/lib/tree-provider.interface.ts
+++ b/libs/globetrotter/types/src/lib/tree-provider.interface.ts
@@ -1,5 +1,0 @@
-export interface TreeProvider<T> {
-  getId(item: T): string;
-  getChildren(item: T): T[];
-  getParent?(item: T): T | undefined;
-}

--- a/libs/globetrotter/ui/src/index.ts
+++ b/libs/globetrotter/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/globetrotter-ui.module';
 
 export * from './lib/animations';
+export * from './lib/nested-checkboxes/nested-checkboxes.component';
 export * from './lib/fixed-slideable-panel/fixed-slideable-panel.component';
 export * from './lib/flip-card/flip-card.component';
 export * from './lib/radio-buttons/radio-buttons.component';

--- a/libs/globetrotter/ui/src/lib/checkbox/checkbox.component.ts
+++ b/libs/globetrotter/ui/src/lib/checkbox/checkbox.component.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { CheckboxState } from '@atocha/globetrotter/types';
+export type CheckboxState = 'checked' | 'unchecked' | 'indeterminate';
 
 @Component({
   selector: 'ui-checkbox',

--- a/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
+++ b/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
@@ -14,7 +14,10 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { reduce } from 'lodash-es';
 
-import { CheckboxStates, TreeProvider } from '../nested-checkboxes/nested-checkboxes.component';
+import {
+  CheckboxStates,
+  TreeProvider,
+} from '../nested-checkboxes/nested-checkboxes.component';
 
 type Counts = Record<string, number>;
 

--- a/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
+++ b/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
@@ -14,7 +14,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { reduce } from 'lodash-es';
 
-import { CheckboxStates, TreeProvider } from '@atocha/globetrotter/types';
+import { CheckboxStates, TreeProvider } from '../nested-checkboxes/nested-checkboxes.component';
 
 type Counts = Record<string, number>;
 

--- a/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
+++ b/libs/globetrotter/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
@@ -12,12 +12,11 @@ import {
   forwardRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Dictionary } from 'lodash';
 import { reduce } from 'lodash-es';
 
 import { CheckboxStates, TreeProvider } from '@atocha/globetrotter/types';
 
-type Counts = Dictionary<number>;
+type Counts = Record<string, number>;
 
 @Component({
   selector: 'ui-nested-checkboxes-with-counts',

--- a/libs/globetrotter/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
+++ b/libs/globetrotter/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
@@ -19,7 +19,6 @@ export interface TreeProvider<T> {
   getParent?(item: T): T | undefined;
 }
 
-
 @Component({
   selector: 'ui-nested-checkboxes',
   templateUrl: './nested-checkboxes.component.html',

--- a/libs/globetrotter/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
+++ b/libs/globetrotter/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
@@ -9,11 +9,16 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
-import {
-  CheckboxState,
-  CheckboxStates,
-  TreeProvider,
-} from '@atocha/globetrotter/types';
+import { CheckboxState } from '../checkbox/checkbox.component';
+
+export type CheckboxStates = Record<string, CheckboxState>;
+
+export interface TreeProvider<T> {
+  getId(item: T): string;
+  getChildren(item: T): T[];
+  getParent?(item: T): T | undefined;
+}
+
 
 @Component({
   selector: 'ui-nested-checkboxes',


### PR DESCRIPTION
1. Globally refactors lodash `Dictionary` type to TS `Record`
2. Creates new `PlaceSelection` and `PlaceSelectionState` to free up `CheckboxStates`
3. Moves `CheckboxStates` and `TreeProvider` definitions to `nested-checkboxes`. Deletes both definitions from `data-access` lib
4. Writes `.spec` file for SelectService