### PR TITLE
Sets `ViewEncapsulation: None` in `core-ui` components

### DIFF
--- a/apps/core-ui-e2e/src/integration/nested-checkboxes-with-counts.cy.ts
+++ b/apps/core-ui-e2e/src/integration/nested-checkboxes-with-counts.cy.ts
@@ -9,7 +9,7 @@ describe('NestedCheckboxesWithCountsComponent', () => {
   }
 
   beforeEach(() => {
-    checkboxSelector = '[data-test="core-ui-nested-checkbox"]';
+    checkboxSelector = '[data-test="core-nested-checkbox"]';
     stories = {
       noneSelected:
         '/iframe.html?id=nestedcheckboxeswithcountscomponent--none-selected',

--- a/apps/core-ui-e2e/src/integration/nested-checkboxes-with-counts.cy.ts
+++ b/apps/core-ui-e2e/src/integration/nested-checkboxes-with-counts.cy.ts
@@ -20,12 +20,6 @@ describe('NestedCheckboxesWithCountsComponent', () => {
     };
   });
 
-  it('Renders checkboxes correctly', () => {
-    cy.visit(stories.noneSelected)
-      .get(checkboxSelector)
-      .should('have.length', 9);
-  });
-
   it('Displays all states correctly when model is passed in', () => {
     cy.visit(stories.someSelected);
 

--- a/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
+++ b/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
@@ -3,10 +3,7 @@ describe('NestedCheckboxesComponent', () => {
   let inputSelector = '';
   let stories: Record<string, string> = {};
 
-  function assertIndentation(
-    place: string,
-    indentation: number
-  ): void {
+  function assertIndentation(place: string, indentation: number): void {
     cy.get(checkboxSelector)
       .contains(place)
       .parent()

--- a/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
+++ b/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
@@ -3,6 +3,16 @@ describe('NestedCheckboxesComponent', () => {
   let inputSelector = '';
   let stories: Record<string, string> = {};
 
+  function assertIndentation(
+    place: string,
+    indentation: number
+  ): void {
+    cy.get(checkboxSelector)
+      .contains(place)
+      .parent()
+      .should('have.css', 'margin-left', `${indentation}px`);
+  }
+
   function assertState(
     place: string,
     state: 'checked' | 'unchecked' | 'indeterminate'
@@ -39,6 +49,16 @@ describe('NestedCheckboxesComponent', () => {
     cy.visit(stories.noneSelected)
       .get(checkboxSelector)
       .should('have.length', 9);
+
+    assertIndentation('Africa', 0);
+    assertIndentation('Southern Africa', 24);
+    assertIndentation('Swaziland', 48);
+    assertIndentation('Namibia', 48);
+    assertIndentation('Central Africa', 24);
+    assertIndentation('Northern Africa', 24);
+    assertIndentation('Morocco', 48);
+    assertIndentation('Marrakesh', 72);
+    assertIndentation('Fes', 72);
   });
 
   it('Displays all states correctly when model is passed in', () => {

--- a/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
+++ b/apps/core-ui-e2e/src/integration/nested-checkboxes.cy.ts
@@ -26,8 +26,8 @@ describe('NestedCheckboxesComponent', () => {
   }
 
   beforeEach(() => {
-    checkboxSelector = '[data-test="core-ui-nested-checkbox"]';
-    inputSelector = '[data-test="core-ui-checkbox"]';
+    checkboxSelector = '[data-test="core-nested-checkbox"]';
+    inputSelector = '[data-test="core-checkbox-input"]';
     stories = {
       noneSelected: '/iframe.html?id=nestedcheckboxescomponent--none-selected',
       someSelected: '/iframe.html?id=nestedcheckboxescomponent--some-selected',

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -35,3 +35,36 @@ sup {
 .bold {
   font-weight: map-get($font-weight, bold);
 }
+
+// Component styling overrides
+
+.core-nested-checkboxes-with-counts {
+  .core-nested-checkboxes {
+    --checkbox-margin: #{map-get($spacing, 8)};
+  }
+
+  .core-checkbox {
+    --checkbox-size: #{map-get($font-size, 20)};
+    --hover-color: #{map-get($color, medium)};
+    --label-margin: #{map-get($spacing, 12)};
+  }
+
+  .core-nested-checkboxes__top.core-checkbox--checked,
+  .core-nested-checkboxes__top.core-checkbox--indeterminate {
+    --checkbox-color: #{map-get($color, lightest)};
+    --checkmark-color: #{map-get($color, darkest)};
+    --checkbox-background: #{map-get($color, lightest)};
+  }
+
+  .core-checkbox--checked,
+  .core-checkbox--indeterminate {
+    --checkbox-color: #{map-get($color, lightest)};
+    --checkmark-color: #{map-get($color, lightest)};
+  }
+
+  .core-checkbox--unchecked {
+    --checkbox-color: #{map-get($color, medium)};
+    --checkmark-color: #{map-get($color, medium)};
+    color: map-get($color, medium);
+  }
+}

--- a/libs/core/ui/.storybook/storybook-wrapper/storybook-wrapper.component.scss
+++ b/libs/core/ui/.storybook/storybook-wrapper/storybook-wrapper.component.scss
@@ -4,18 +4,18 @@
     --hover-color: beige;
     --label-margin: 12px;
 
-    &.core-ui-checkbox--checked {
+    &.core-checkbox--checked {
       --checkbox-color: aquamarine;
       --checkmark-color: darkblue;
       --checkbox-background: aquamarine;
     }
 
-    &.core-ui-checkbox--indeterminate {
+    &.core-checkbox--indeterminate {
       --checkbox-color: goldenrod;
       --checkmark-color: goldenrod;
     }
 
-    &.core-ui-checkbox--unchecked {
+    &.core-checkbox--unchecked {
       --checkbox-color: darkseagreen;
       color: darkgray;
     }
@@ -24,62 +24,58 @@
   .custom-nested-checkboxes {
     --checkbox-margin: 8px;
 
-    ::ng-deep {
-      .checkbox {
-        --checkbox-size: 20px;
-        --hover-color: beige;
-        --label-margin: 12px;
-      }
+    .core-checkbox {
+      --checkbox-size: 20px;
+      --hover-color: beige;
+      --label-margin: 12px;
+    }
 
-      &.checkbox--top.core-ui-checkbox--checked,
-      &.checkbox--top.core-ui-checkbox--indeterminate {
-        --checkbox-color: aquamarine;
-        --checkmark-color: darkblue;
-        --checkbox-background: aquamarine;
-      }
+    .core-nested-checkboxes__top.core-checkbox--checked,
+    .core-nested-checkboxes__top.core-checkbox--indeterminate {
+      --checkbox-color: aquamarine;
+      --checkmark-color: darkblue;
+      --checkbox-background: aquamarine;
+    }
 
-      &.core-ui-checkbox--checked,
-      &.core-ui-checkbox--indeterminate {
-        --checkbox-color: goldenrod;
-        --checkmark-color: goldenrod;
-      }
+    .core-checkbox--checked,
+    .core-checkbox--indeterminate {
+      --checkbox-color: goldenrod;
+      --checkmark-color: goldenrod;
+    }
 
-      &.checkbox--unchecked {
-        --checkbox-color: darkseagreen;
-        color: darkgray;
-      }
+    .checkbox--unchecked {
+      --checkbox-color: darkseagreen;
+      color: darkgray;
     }
   }
 
   .custom-nested-checkboxes-with-counts {
-    ::ng-deep {
-      .nested-checkboxes {
-        --checkbox-margin: 8px;
-      }
+    .core-nested-checkboxes {
+      --checkbox-margin: 8px;
+    }
 
-      .checkbox {
-        --checkbox-size: 20px;
-        --hover-color: beige;
-        --label-margin: 12px;
-      }
+    .core-checkbox {
+      --checkbox-size: 20px;
+      --hover-color: beige;
+      --label-margin: 12px;
+    }
 
-      &.checkbox--top.core-ui-checkbox--checked,
-      &.checkbox--top.core-ui-checkbox--indeterminate {
-        --checkbox-color: aquamarine;
-        --checkmark-color: darkblue;
-        --checkbox-background: aquamarine;
-      }
+    .core-nested-checkboxes__top.core-checkbox--checked,
+    .core-nested-checkboxes__top.core-checkbox--indeterminate {
+      --checkbox-color: aquamarine;
+      --checkmark-color: darkblue;
+      --checkbox-background: aquamarine;
+    }
 
-      &.core-ui-checkbox--checked,
-      &.core-ui-checkbox--indeterminate {
-        --checkbox-color: goldenrod;
-        --checkmark-color: goldenrod;
-      }
+    .core-checkbox--checked,
+    .core-checkbox--indeterminate {
+      --checkbox-color: goldenrod;
+      --checkmark-color: goldenrod;
+    }
 
-      &.checkbox--unchecked {
-        --checkbox-color: darkseagreen;
-        color: darkgray;
-      }
+    .checkbox--unchecked {
+      --checkbox-color: darkseagreen;
+      color: darkgray;
     }
   }
 }

--- a/libs/core/ui/src/lib/checkbox/checkbox.component.html
+++ b/libs/core/ui/src/lib/checkbox/checkbox.component.html
@@ -3,7 +3,7 @@
 >
   <input class="core-checkbox__input"
     type="checkbox"
-    data-test="core-ui-checkbox"
+    data-test="core-checkbox-input"
     [indeterminate]="indeterminate"
     [disabled]="disabled"
     [ngModel]="checked"

--- a/libs/core/ui/src/lib/checkbox/checkbox.component.html
+++ b/libs/core/ui/src/lib/checkbox/checkbox.component.html
@@ -1,7 +1,7 @@
-<label class="container"
-  [class.container--disabled]="disabled"
+<label class="core-checkbox__container"
+  [class.core-checkbox__container--disabled]="disabled"
 >
-  <input class="input"
+  <input class="core-checkbox__input"
     type="checkbox"
     data-test="core-ui-checkbox"
     [indeterminate]="indeterminate"
@@ -9,13 +9,13 @@
     [ngModel]="checked"
     (ngModelChange)="onChange($event)"
   />
-  <div class="checkbox">
+  <div class="core-checkbox__checkbox">
     <div *ngIf="checked || indeterminate"
-      class="checkmark"
-      [class.checkmark--indeterminate]="indeterminate"
+      class="core-checkbox__checkmark"
+      [class.core-checkbox__checkmark--indeterminate]="indeterminate"
     ></div>
   </div>
-  <div class="label">
+  <div class="core-checkbox__label">
     <ng-content></ng-content>
   </div>
 </label>

--- a/libs/core/ui/src/lib/checkbox/checkbox.component.scss
+++ b/libs/core/ui/src/lib/checkbox/checkbox.component.scss
@@ -1,4 +1,6 @@
-:host {
+$checkmark-width: 2px;
+
+.core-checkbox {
   display: inline-flex;
   position: relative;
   --border-radius: 2px;
@@ -8,69 +10,65 @@
   --checkmark-color: gray;
   --hover-color: lightgray;
   --label-margin: 4px;
-}
 
-$checkmark-width: 2px;
+  &__container {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    font-size: var(--font-size);
 
-.container {
-  display: inline-flex;
-  align-items: center;
-  position: relative;
-  font-size: var(--font-size);
-
-  &:hover {
-    .checkbox {
+    &:hover .core-checkbox__checkbox {
       background: var(--hover-color);
     }
-  }
 
-  &--disabled {
-    &:hover .checkbox {
-      background: none;
+    &--disabled {
+      &:hover .core-checkbox__checkbox {
+        background: none;
+      }
     }
   }
-}
 
-// Hide the default checkbox input
-.input {
-  position: absolute;
-  margin: 0;
-  opacity: 0;
-}
-
-.checkbox {
-  position: relative;
-  height: var(--checkbox-size);
-  width: var(--checkbox-size);
-  background: var(--checkbox-background);
-  border: $checkmark-width solid var(--checkbox-color);
-  border-radius: var(--border-radius);
-}
-
-.checkmark {
-  display: block;
-  position: absolute;
-  top: calc(var(--checkbox-size) * -0.05);
-  left: calc(var(--checkbox-size) * 0.2);
-  width: calc(var(--checkbox-size) * 0.37);
-  height: calc(var(--checkbox-size) * 0.7);
-  border: solid var(--checkmark-color);
-  border-width: 0 $checkmark-width $checkmark-width 0;
-  transform: rotate(45deg);
-
-  &--indeterminate {
-    top: 50%;
-    left: 50%;
-    width: 8px;
-    height: unset;
-    border: unset;
-    border-top: $checkmark-width solid var(--checkmark-color);
-    transform: translate(-50%, -50%);
+  // Hide the default checkbox input
+  &__input {
+    position: absolute;
+    margin: 0;
+    opacity: 0;
   }
-}
 
-.label {
-  display: inline-flex;
-  margin-left: var(--label-margin);
-  user-select: none;
+  &__checkbox {
+    position: relative;
+    height: var(--checkbox-size);
+    width: var(--checkbox-size);
+    background: var(--checkbox-background);
+    border: $checkmark-width solid var(--checkbox-color);
+    border-radius: var(--border-radius);
+  }
+
+  &__checkmark {
+    display: block;
+    position: absolute;
+    top: calc(var(--checkbox-size) * -0.05);
+    left: calc(var(--checkbox-size) * 0.2);
+    width: calc(var(--checkbox-size) * 0.37);
+    height: calc(var(--checkbox-size) * 0.7);
+    border: solid var(--checkmark-color);
+    border-width: 0 $checkmark-width $checkmark-width 0;
+    transform: rotate(45deg);
+
+    &--indeterminate {
+      top: 50%;
+      left: 50%;
+      width: 8px;
+      height: unset;
+      border: unset;
+      border-top: $checkmark-width solid var(--checkmark-color);
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  &__label {
+    display: inline-flex;
+    margin-left: var(--label-margin);
+    user-select: none;
+  }
 }

--- a/libs/core/ui/src/lib/checkbox/checkbox.component.ts
+++ b/libs/core/ui/src/lib/checkbox/checkbox.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   HostBinding,
+  ViewEncapsulation,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -12,6 +13,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   templateUrl: './checkbox.component.html',
   styleUrls: ['./checkbox.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -31,10 +33,11 @@ export class CheckboxComponent implements ControlValueAccessor {
   @HostBinding('class')
   get hostClasses(): Record<string, boolean> {
     return {
-      'core-ui-checkbox--checked': this.checked && !this.indeterminate,
-      'core-ui-checkbox--unchecked': !this.checked && !this.indeterminate,
-      'core-ui-checkbox--indeterminate': this.indeterminate,
-      'core-ui-checkbox--disabled': this.disabled,
+      'core-checkbox': true,
+      'core-checkbox--checked': this.checked && !this.indeterminate,
+      'core-checkbox--unchecked': !this.checked && !this.indeterminate,
+      'core-checkbox--indeterminate': this.indeterminate,
+      'core-checkbox--disabled': this.disabled,
     };
   }
 

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.html
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.html
@@ -3,6 +3,7 @@
   [getId]="getId"
   [getChildren]="getChildren"
   [itemTemplate]="checkbox"
+  [indentation]="indentation"
   [ngModel]="states"
   (ngModelChange)="onChange($event)"
 ></core-nested-checkboxes>

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.html
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.html
@@ -1,5 +1,4 @@
 <core-nested-checkboxes
-  class="nested-checkboxes"
   [item]="item"
   [getId]="getId"
   [getChildren]="getChildren"

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.scss
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.scss
@@ -1,3 +1,3 @@
-:host {
+.core-nested-checkboxes-with-counts {
   display: block;
 }

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.stories.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.stories.ts
@@ -27,6 +27,7 @@ import { NestedCheckboxesWithCountsComponent } from './nested-checkboxes-with-co
 
 type NestedCheckboxesWithCountsArgs = Pick<
   NestedCheckboxesComponent<TestItem>,
+  'indentation' |
   'states'
 > & {
   className: string;
@@ -58,6 +59,7 @@ export default {
 } as Meta<NestedCheckboxesWithCountsArgs>;
 
 const Template: Story<NestedCheckboxesWithCountsArgs> = ({
+  indentation,
   states,
   className,
   onNgModelChange,
@@ -69,6 +71,7 @@ const Template: Story<NestedCheckboxesWithCountsArgs> = ({
     getId,
     getChildren,
     getCounts,
+    indentation,
     states,
     className,
     onNgModelChange,
@@ -82,6 +85,7 @@ const Template: Story<NestedCheckboxesWithCountsArgs> = ({
       [getId]="getId"
       [getChildren]="getChildren"
       [getLeafItemCount]="getCounts"
+      [indentation]="indentation"
       [ngModel]="states"
       (ngModelChange)="states = $event; onNgModelChange($event)"
       (selectedChange)="onSelectedChange($event)"
@@ -91,9 +95,9 @@ const Template: Story<NestedCheckboxesWithCountsArgs> = ({
 });
 
 export const noneSelected = Template.bind({});
-noneSelected.args = {
+noneSelected.args = createArgs({
   states: {},
-};
+});
 
 export const someSelected = Template.bind({});
 someSelected.args = createArgs({
@@ -112,11 +116,13 @@ withCustomStyling.args = createArgs({
 });
 
 function createArgs({
+  indentation = 24,
   states = {},
   className = '',
 }: {
+  indentation?: number,
   states?: CheckboxStates;
   className?: string;
 }) {
-  return { states, className };
+  return { indentation, states, className };
 }

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.stories.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.stories.ts
@@ -27,8 +27,7 @@ import { NestedCheckboxesWithCountsComponent } from './nested-checkboxes-with-co
 
 type NestedCheckboxesWithCountsArgs = Pick<
   NestedCheckboxesComponent<TestItem>,
-  'indentation' |
-  'states'
+  'indentation' | 'states'
 > & {
   className: string;
   onNgModelChange: InputType | undefined;
@@ -120,7 +119,7 @@ function createArgs({
   states = {},
   className = '',
 }: {
-  indentation?: number,
+  indentation?: number;
   states?: CheckboxStates;
   className?: string;
 }) {

--- a/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes-with-counts/nested-checkboxes-with-counts.component.ts
@@ -11,6 +11,7 @@ import {
   forwardRef,
   SimpleChanges,
   OnChanges,
+  ViewEncapsulation,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { reduce } from 'lodash-es';
@@ -24,6 +25,10 @@ type Counts = Record<string, number>;
   templateUrl: './nested-checkboxes-with-counts.component.html',
   styleUrls: ['./nested-checkboxes-with-counts.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'core-nested-checkboxes-with-counts',
+  },
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.html
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.html
@@ -12,8 +12,7 @@
   let-parent="level > 0"
 >
   <core-checkbox
-    class="checkbox"
-    [class.checkbox--top]="!parent"
+    [class.core-nested-checkboxes__top]="!parent"
     [style.margin-left.px]="level * indentation"
     data-test="core-ui-nested-checkbox"
     [indeterminate]="states[getId(item)] === 'indeterminate'"

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.html
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.html
@@ -14,7 +14,7 @@
   <core-checkbox
     [class.core-nested-checkboxes__top]="!parent"
     [style.margin-left.px]="level * indentation"
-    data-test="core-ui-nested-checkbox"
+    data-test="core-nested-checkbox"
     [indeterminate]="states[getId(item)] === 'indeterminate'"
     [ngModel]="states[getId(item)] === 'checked'"
     (ngModelChange)="onChange($event, item)"

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.scss
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.scss
@@ -1,8 +1,8 @@
-:host {
+.core-nested-checkboxes {
   display: block;
   --checkbox-margin: 4px;
 }
 
-.checkbox {
+.core-checkbox {
   margin-bottom: var(--checkbox-margin);
 }

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.stories.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.stories.ts
@@ -25,6 +25,7 @@ import {
 
 type NestedCheckboxesArgs = Pick<
   NestedCheckboxesComponent<TestItem>,
+  'indentation' |
   'states'
 > & {
   className: string;
@@ -51,6 +52,7 @@ export default {
 } as Meta<NestedCheckboxesArgs>;
 
 const Template: Story<NestedCheckboxesArgs> = ({
+  indentation,
   states,
   className,
   onClick,
@@ -59,6 +61,7 @@ const Template: Story<NestedCheckboxesArgs> = ({
     item: AFRICA,
     getId,
     getChildren,
+    indentation,
     states,
     className,
     onClick,
@@ -69,6 +72,7 @@ const Template: Story<NestedCheckboxesArgs> = ({
       [item]="item"
       [getId]="getId"
       [getChildren]="getChildren"
+      [indentation]="indentation"
       [ngModel]="states"
       (ngModelChange)="states = $event; onClick($event)"
     ></core-nested-checkboxes>
@@ -76,9 +80,9 @@ const Template: Story<NestedCheckboxesArgs> = ({
 });
 
 export const noneSelected = Template.bind({});
-noneSelected.args = {
+noneSelected.args = createArgs({
   states: {},
-};
+});
 
 export const someSelected = Template.bind({});
 someSelected.args = createArgs({
@@ -97,11 +101,13 @@ withCustomStyling.args = createArgs({
 });
 
 function createArgs({
+  indentation = 24,
   states = {},
   className = '',
 }: {
+  indentation?: number
   states?: CheckboxStates;
   className?: string;
 }) {
-  return { states, className };
+  return { indentation, states, className };
 }

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.stories.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.stories.ts
@@ -25,8 +25,7 @@ import {
 
 type NestedCheckboxesArgs = Pick<
   NestedCheckboxesComponent<TestItem>,
-  'indentation' |
-  'states'
+  'indentation' | 'states'
 > & {
   className: string;
   onClick: InputType | undefined;
@@ -105,7 +104,7 @@ function createArgs({
   states = {},
   className = '',
 }: {
-  indentation?: number
+  indentation?: number;
   states?: CheckboxStates;
   className?: string;
 }) {

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
@@ -8,6 +8,8 @@ import {
   ChangeDetectorRef,
   OnChanges,
   SimpleChanges,
+  ViewEncapsulation,
+  HostListener,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
@@ -28,6 +30,10 @@ interface ItemsRecord<T> {
   templateUrl: './nested-checkboxes.component.html',
   styleUrls: ['./nested-checkboxes.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'core-nested-checkboxes',
+  },
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
+++ b/libs/core/ui/src/lib/nested-checkboxes/nested-checkboxes.component.ts
@@ -9,7 +9,6 @@ import {
   OnChanges,
   SimpleChanges,
   ViewEncapsulation,
-  HostListener,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 

--- a/libs/core/ui/src/lib/tree/tree.component.html
+++ b/libs/core/ui/src/lib/tree/tree.component.html
@@ -18,7 +18,7 @@
 </ng-container>
 
 <ng-template #defaultTemplate let-item>
-  <span data-test="ui-tree-default-item">
+  <span data-test="core-tree-default-item">
     {{ getId(item) }}
   </span>
 </ng-template>

--- a/libs/core/ui/src/lib/tree/tree.component.scss
+++ b/libs/core/ui/src/lib/tree/tree.component.scss
@@ -1,3 +1,3 @@
-:host {
+.core-tree {
   display: block;
 }

--- a/libs/core/ui/src/lib/tree/tree.component.spec.ts
+++ b/libs/core/ui/src/lib/tree/tree.component.spec.ts
@@ -77,7 +77,7 @@ describe('TreeComponent', () => {
     fixture.detectChanges();
 
     const name = fixture.nativeElement
-      .querySelector('[data-test="ui-tree-default-item"]')
+      .querySelector('[data-test="core-tree-default-item"]')
       .textContent.trim();
     expect(name).toBe('1');
   });
@@ -94,7 +94,7 @@ describe('TreeComponent', () => {
     fixture.detectChanges();
 
     const items = fixture.nativeElement.querySelectorAll(
-      '[data-test="ui-tree-default-item"]'
+      '[data-test="core-tree-default-item"]'
     );
     const name = items[1].textContent.trim();
     const childName = items[2].textContent.trim();

--- a/libs/core/ui/src/lib/tree/tree.component.ts
+++ b/libs/core/ui/src/lib/tree/tree.component.ts
@@ -19,7 +19,7 @@ interface TreeNodeContext<T> {
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'core-tree',
-  }
+  },
 })
 export class TreeComponent<T> implements OnInit {
   /**

--- a/libs/core/ui/src/lib/tree/tree.component.ts
+++ b/libs/core/ui/src/lib/tree/tree.component.ts
@@ -17,6 +17,9 @@ interface TreeNodeContext<T> {
   templateUrl: './tree.component.html',
   styleUrls: ['./tree.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'core-tree',
+  }
 })
 export class TreeComponent<T> implements OnInit {
   /**

--- a/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.scss
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.scss
@@ -64,39 +64,6 @@
     }
   }
 
-  &__checkboxes {
-    ::ng-deep {
-      .nested-checkboxes {
-        --checkbox-margin: #{map-get($spacing, 8)};
-      }
-
-      .checkbox {
-        --checkbox-size: #{map-get($font-size, 20)};
-        --hover-color: #{map-get($color, medium)};
-        --label-margin: #{map-get($spacing, 12)};
-      }
-
-      &.checkbox--top.core-ui-checkbox--checked,
-      &.checkbox--top.core-ui-checkbox--indeterminate {
-        --checkbox-color: #{map-get($color, lightest)};
-        --checkmark-color: #{map-get($color, darkest)};
-        --checkbox-background: #{map-get($color, lightest)};
-      }
-
-      &.core-ui-checkbox--checked,
-      &.core-ui-checkbox--indeterminate {
-        --checkbox-color: #{map-get($color, lightest)};
-        --checkmark-color: #{map-get($color, lightest)};
-      }
-
-      &.core-ui-checkbox--unchecked {
-        --checkbox-color: #{map-get($color, medium)};
-        --checkmark-color: #{map-get($color, medium)};
-        color: map-get($color, medium);
-      }
-    }
-  }
-
   @include tablet {
     padding: map-get($spacing, 16) 0;
   }


### PR DESCRIPTION
1. Turns off ViewEncapsulation on all `core-ui` components and sets `core-{{ NAME }}` host classes
2. Standardizes all `data-test` attributes to `core-{{ NAME }}-{{ ELEMENT }}`
3. Adds `indentation` property to nested-checkboxes-with-counts (which passes through to nested-checkboxes) and updates e2e tests to check that property works