### PR TITLE
General cleanup

### DIFF
--- a/apps/globetrotter/src/app/app-routing.module.ts
+++ b/apps/globetrotter/src/app/app-routing.module.ts
@@ -49,7 +49,6 @@ const routes: Routes = [
     RouterModule.forRoot(routes, {
       preloadingStrategy: PreloadAllModules,
       scrollPositionRestoration: 'enabled',
-      relativeLinkResolution: 'legacy',
     }),
   ],
   exports: [RouterModule],

--- a/libs/globetrotter/data-access/src/lib/services/country.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/country.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, shareReplay } from 'rxjs';
 import { groupBy } from 'lodash-es';
 
 import { sort } from '@atocha/core/util';
@@ -26,9 +26,9 @@ export class CountryService {
     countriesBySubregion: {},
     regions: [],
   });
-  get countries$(): Observable<CountryState> {
-    return this._countriesSubject.asObservable();
-  }
+  countries$ = this._countriesSubject.pipe(
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   constructor(private _apiService: ApiService) {
     this._apiService.fetchCountries().subscribe((countryDtos) => {

--- a/libs/globetrotter/data-access/src/lib/services/error.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/error.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { first, map, shareReplay } from 'rxjs/operators';
 
 interface ErrorState {
   global: string;
@@ -17,9 +17,9 @@ export class ErrorService {
     login: '',
     register: '',
   });
-  get errors$(): Observable<ErrorState> {
-    return this._errorsSubject;
-  }
+  errors$ = this._errorsSubject.pipe(
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   setGlobalError(error: string): void {
     this._errorsSubject

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
@@ -15,7 +15,7 @@ export class QuizService {
     undefined
   );
   quiz$ = this._quizSubject.pipe(
-    shareReplay({ bufferSize: 1, refCount: true }),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   constructor(

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { filter, first, map } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { filter, first, map, shareReplay } from 'rxjs/operators';
 
 import { Route, Country, Selection, Quiz } from '@atocha/globetrotter/types';
 import { CountryService } from './country.service';
@@ -14,9 +14,9 @@ export class QuizService {
   private readonly _quizSubject = new BehaviorSubject<Quiz | undefined>(
     undefined
   );
-  get quiz$(): Observable<Quiz | undefined> {
-    return this._quizSubject.asObservable();
-  }
+  quiz$ = this._quizSubject.pipe(
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
 
   constructor(
     private _countryService: CountryService,

--- a/libs/globetrotter/data-access/src/lib/services/router.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/router.service.ts
@@ -6,8 +6,8 @@ import {
   NavigationCancel,
   NavigationError,
 } from '@angular/router';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { map, filter, distinctUntilChanged } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { map, filter, distinctUntilChanged, shareReplay } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -15,20 +15,16 @@ import { map, filter, distinctUntilChanged } from 'rxjs/operators';
 export class RouterService {
   private _routeSubject = new BehaviorSubject<string>('');
   private _loadingSubject = new BehaviorSubject<boolean>(false);
-
-  get route$(): Observable<string> {
-    return this._routeSubject.pipe(distinctUntilChanged());
-  }
-
-  get loading$(): Observable<boolean> {
-    return this._loadingSubject.pipe(distinctUntilChanged());
-  }
+  route$ = this._routeSubject.pipe(
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  loading$ = this._loadingSubject.pipe(
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
 
   constructor(private _router: Router) {
-    this._intialize();
-  }
-
-  private _intialize(): void {
     this._router.events
       .pipe(
         filter((e): e is NavigationEnd => e instanceof NavigationEnd),

--- a/libs/globetrotter/data-access/src/lib/services/router.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/router.service.ts
@@ -17,11 +17,11 @@ export class RouterService {
   private _loadingSubject = new BehaviorSubject<boolean>(false);
   route$ = this._routeSubject.pipe(
     distinctUntilChanged(),
-    shareReplay({ bufferSize: 1, refCount: true }),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
   loading$ = this._loadingSubject.pipe(
     distinctUntilChanged(),
-    shareReplay({ bufferSize: 1, refCount: true }),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   constructor(private _router: Router) {

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -26,7 +26,7 @@ export class SelectService {
     places: {},
   });
   selection$ = this._selectionSubject.pipe(
-    shareReplay({ bufferSize: 1, refCount: true }),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   constructor(private _countryService: CountryService) {

--- a/libs/globetrotter/data-access/src/lib/services/select.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/select.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { first, map, shareReplay } from 'rxjs/operators';
 
 import {
   QuizType,
@@ -16,21 +16,20 @@ import { CountryService } from './country.service';
   providedIn: 'root',
 })
 export class SelectService {
-  private readonly _paramDict: Record<PlaceSelectionState, string> = {
+  private _paramDict: Record<PlaceSelectionState, string> = {
     checked: '_c',
     indeterminate: '_i',
   };
-  private readonly _selectionSubject: BehaviorSubject<Selection>;
-  get selection$(): Observable<Selection> {
-    return this._selectionSubject.asObservable();
-  }
+  private _selectionSubject = new BehaviorSubject<Selection>({
+    type: QuizType.flagsCountries,
+    quantity: 5,
+    places: {},
+  });
+  selection$ = this._selectionSubject.pipe(
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
 
   constructor(private _countryService: CountryService) {
-    this._selectionSubject = new BehaviorSubject<Selection>({
-      type: QuizType.flagsCountries,
-      quantity: 5,
-      places: {},
-    });
     this._countryService.countries$
       .pipe(map(({ regions }) => regions))
       .subscribe((regions) => {


### PR DESCRIPTION
1. Makes public-facing observables in services properties rather than getters
2. Inlines service init logic where possible
3. Removes unneeded legacy support property from app-routing module