### PR TITLE
Quiz service spec

### DIFF
--- a/libs/core/util/src/lib/quiz.spec.ts
+++ b/libs/core/util/src/lib/quiz.spec.ts
@@ -4,10 +4,9 @@ describe('Quiz', () => {
   it('initializes state when passed no data', () => {
     expect(new Quiz().state).toStrictEqual({
       items: [],
-      itemsTotal: 0,
       currentItem: undefined,
-      currentGuess: 1,
       correctGuesses: 0,
+      totalGuesses: 0,
       accuracy: 100,
       isComplete: false,
     });
@@ -16,10 +15,9 @@ describe('Quiz', () => {
   it('initalizes state when passed data', () => {
     expect(new Quiz(['French', 'Italian', 'Portuguese']).state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: 'French',
-      currentGuess: 1,
       correctGuesses: 0,
+      totalGuesses: 0,
       accuracy: 100,
       isComplete: false,
     });
@@ -31,10 +29,9 @@ describe('Quiz', () => {
 
     expect(quiz.state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: 'Italian',
-      currentGuess: 2,
       correctGuesses: 1,
+      totalGuesses: 1,
       accuracy: 100,
       isComplete: false,
     });
@@ -46,10 +43,9 @@ describe('Quiz', () => {
 
     expect(quiz.state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: 'Italian',
-      currentGuess: 2,
       correctGuesses: 0,
+      totalGuesses: 1,
       accuracy: 0,
       isComplete: false,
     });
@@ -66,10 +62,9 @@ describe('Quiz', () => {
 
     expect(quiz.state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: 'Portuguese',
-      currentGuess: 7,
       correctGuesses: 2,
+      totalGuesses: 6,
       accuracy: 33,
       isComplete: false,
     });
@@ -84,10 +79,9 @@ describe('Quiz', () => {
 
     expect(quiz.state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: undefined,
-      currentGuess: 5,
       correctGuesses: 3,
+      totalGuesses: 4,
       accuracy: 75,
       isComplete: true,
     });
@@ -103,10 +97,9 @@ describe('Quiz', () => {
 
     expect(quiz.state).toStrictEqual({
       items: ['French', 'Italian', 'Portuguese'],
-      itemsTotal: 3,
       currentItem: undefined,
-      currentGuess: 4,
       correctGuesses: 3,
+      totalGuesses: 3,
       accuracy: 100,
       isComplete: true,
     });

--- a/libs/core/util/src/lib/quiz.ts
+++ b/libs/core/util/src/lib/quiz.ts
@@ -1,7 +1,7 @@
 export interface QuizState<T> {
-  items: T[];
-  currentItem: T | undefined;
+  items: readonly T[];
   itemsTotal: number;
+  currentItem: T | undefined;
   currentGuess: number;
   correctGuesses: number;
   accuracy: number;
@@ -9,8 +9,8 @@ export interface QuizState<T> {
 }
 
 export class Quiz<T> {
+  private _items: readonly T[] = [];
   private _queue: T[] = [];
-  private _items: T[] = [];
   private _correctGuesses = 0;
   private _totalGuesses = 0;
   private _accuracy = 100;
@@ -18,9 +18,9 @@ export class Quiz<T> {
 
   get state(): QuizState<T> {
     return {
-      items: this._items.slice(),
+      items: this._items,
       itemsTotal: this._items.length,
-      currentItem: this._queue.slice()[0],
+      currentItem: this._queue[0],
       currentGuess: this._totalGuesses + 1,
       correctGuesses: this._correctGuesses,
       accuracy: this._accuracy,

--- a/libs/core/util/src/lib/quiz.ts
+++ b/libs/core/util/src/lib/quiz.ts
@@ -36,8 +36,6 @@ export class Quiz<T> {
       return;
     }
 
-    this._totalGuesses++;
-
     if (isCorrect) {
       this._queue.shift();
       this._correctGuesses++;
@@ -48,6 +46,7 @@ export class Quiz<T> {
       }
     }
 
+    this._totalGuesses++;
     this._accuracy = Math.round(
       (this._correctGuesses / this._totalGuesses) * 100
     );

--- a/libs/core/util/src/lib/quiz.ts
+++ b/libs/core/util/src/lib/quiz.ts
@@ -1,9 +1,8 @@
 export interface QuizState<T> {
   items: readonly T[];
-  itemsTotal: number;
   currentItem: T | undefined;
-  currentGuess: number;
   correctGuesses: number;
+  totalGuesses: number;
   accuracy: number;
   isComplete: boolean;
 }
@@ -19,10 +18,9 @@ export class Quiz<T> {
   get state(): QuizState<T> {
     return {
       items: this._items,
-      itemsTotal: this._items.length,
       currentItem: this._queue[0],
-      currentGuess: this._totalGuesses + 1,
       correctGuesses: this._correctGuesses,
+      totalGuesses: this._totalGuesses,
       accuracy: this._accuracy,
       isComplete: this._isComplete,
     };

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { QuizType } from '@atocha/globetrotter/types';
+import { QuizService } from "./quiz.service";
+import { SelectService } from "./select.service";
+
+describe('QuizService', () => {
+  let service: QuizService;
+  const mockSelectService: Pick<SelectService, 'selection$'> = {
+    selection$: of({
+      type: QuizType.flagsCountries,
+      quantity: 3,
+      places: {}
+    }),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        {
+          provide: SelectService,
+          useValue: mockSelectService,
+        },
+      ],
+    });
+    service = TestBed.inject(QuizService);
+  });
+
+  it('renders', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
@@ -5,7 +5,6 @@ import { shuffle } from 'lodash-es';
 
 import { QuizType } from '@atocha/globetrotter/types';
 import { QuizService } from "./quiz.service";
-import { SelectService } from "./select.service";
 import { PlaceService } from './place.service';
 import {
   DJIBOUTI,
@@ -31,13 +30,6 @@ describe('QuizService', () => {
       regions: [],
     })
   };
-  const mockSelectService: Pick<SelectService, 'selection$'> = {
-    selection$: of({
-      type: QuizType.flagsCountries,
-      quantity: 2,
-      places: {}
-    }),
-  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -46,10 +38,6 @@ describe('QuizService', () => {
         {
           provide: PlaceService,
           useValue: mockPlaceService,
-        },
-        {
-          provide: SelectService,
-          useValue: mockSelectService,
         },
       ],
     });
@@ -60,13 +48,13 @@ describe('QuizService', () => {
     jest.resetAllMocks();
   });
 
-  it('renders and mocks shuffle', () => {
+  it('renders', () => {
     expect(service).toBeTruthy();
     expect(jest.isMockFunction(shuffle)).toBeTruthy();
     expect(shuffle([1, 2, 3])).toEqual([1, 2, 3]);
   });
 
-  it('initializes quiz', (done) => {
+  it('has correct state after initializing quiz', (done) => {
     service.initializeQuiz({
       type: QuizType.flagsCountries,
       quantity: 2,
@@ -85,6 +73,35 @@ describe('QuizService', () => {
         correctGuesses: 0,
         totalGuesses: 0,
         accuracy: 100,
+        isComplete: false,
+      });
+      done();
+    });
+  });
+
+  it('has correct state after updating quiz', (done) => {
+    service.initializeQuiz({
+      type: QuizType.flagsCountries,
+      quantity: 4,
+      places: {
+        Africa: 'checked',
+        'Eastern Africa': 'checked',
+        'Southeast Europe': 'checked',
+        'South-Eastern Asia': 'checked',
+      },
+    });
+
+    service.updateQuiz(false);
+    service.updateQuiz(false);
+    service.updateQuiz(true);
+
+    service.quiz$.subscribe((value) => {
+      expect(value).toEqual({
+        items: [DJIBOUTI, SEYCHELLES, MONTENEGRO, PHILIPPINES],
+        currentItem: PHILIPPINES,
+        correctGuesses: 1,
+        totalGuesses: 3,
+        accuracy: 33,
         isComplete: false,
       });
       done();

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 import { shuffle } from 'lodash-es';
 
 import { QuizType } from '@atocha/globetrotter/types';
-import { QuizService } from "./quiz.service";
+import { QuizService } from './quiz.service';
 import { PlaceService } from './place.service';
 import {
   DJIBOUTI,
@@ -28,7 +28,7 @@ describe('QuizService', () => {
         'South-Eastern Asia': [PHILIPPINES],
       },
       regions: [],
-    })
+    }),
   };
 
   beforeEach(() => {

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.spec.ts
@@ -1,26 +1,52 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
+import { shuffle } from 'lodash-es';
 
 import { QuizType } from '@atocha/globetrotter/types';
 import { QuizService } from "./quiz.service";
 import { SelectService } from "./select.service";
+import { PlaceService } from './place.service';
+import {
+  DJIBOUTI,
+  MONTENEGRO,
+  PHILIPPINES,
+  SEYCHELLES,
+} from '../mock-data/countries';
+
+jest.mock('lodash-es', () => ({
+  shuffle: jest.fn(<T>(arr: T[]) => arr.slice()),
+}));
 
 describe('QuizService', () => {
   let service: QuizService;
+  const mockPlaceService: Pick<PlaceService, 'places$'> = {
+    places$: of({
+      countries: [],
+      countriesBySubregion: {
+        'Eastern Africa': [DJIBOUTI, SEYCHELLES],
+        'Southeast Europe': [MONTENEGRO],
+        'South-Eastern Asia': [PHILIPPINES],
+      },
+      regions: [],
+    })
+  };
   const mockSelectService: Pick<SelectService, 'selection$'> = {
     selection$: of({
       type: QuizType.flagsCountries,
-      quantity: 3,
+      quantity: 2,
       places: {}
     }),
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      imports: [RouterTestingModule],
       providers: [
+        {
+          provide: PlaceService,
+          useValue: mockPlaceService,
+        },
         {
           provide: SelectService,
           useValue: mockSelectService,
@@ -30,7 +56,38 @@ describe('QuizService', () => {
     service = TestBed.inject(QuizService);
   });
 
-  it('renders', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders and mocks shuffle', () => {
     expect(service).toBeTruthy();
+    expect(jest.isMockFunction(shuffle)).toBeTruthy();
+    expect(shuffle([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('initializes quiz', (done) => {
+    service.initializeQuiz({
+      type: QuizType.flagsCountries,
+      quantity: 2,
+      places: {
+        Africa: 'checked',
+        'Eastern Africa': 'checked',
+        'Southeast Europe': 'checked',
+        'South-Eastern Asia': 'checked',
+      },
+    });
+
+    service.quiz$.subscribe((value) => {
+      expect(value).toEqual({
+        items: [DJIBOUTI, SEYCHELLES],
+        currentItem: DJIBOUTI,
+        correctGuesses: 0,
+        totalGuesses: 0,
+        accuracy: 100,
+        isComplete: false,
+      });
+      done();
+    });
   });
 });

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
@@ -13,9 +13,9 @@ import { shuffle } from 'lodash-es';
 })
 export class QuizService {
   private _quiz: Quiz<Country> | undefined = undefined;
-  private _stateSubject = new BehaviorSubject<
-    QuizState<Country> | undefined
-  >(undefined);
+  private _stateSubject = new BehaviorSubject<QuizState<Country> | undefined>(
+    undefined
+  );
   quiz$ = this._stateSubject.pipe(
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
+++ b/libs/globetrotter/data-access/src/lib/services/quiz.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { filter, first, map, shareReplay } from 'rxjs/operators';
+import { filter, map, shareReplay } from 'rxjs/operators';
 
-import { Quiz } from '@atocha/core/util';
+import { Quiz, QuizState } from '@atocha/core/util';
 import { Route, Country, Selection } from '@atocha/globetrotter/types';
 import { PlaceService } from './place.service';
 import { RouterService } from './router.service';
@@ -12,11 +12,11 @@ import { shuffle } from 'lodash-es';
   providedIn: 'root',
 })
 export class QuizService {
-  private readonly _quizSubject = new BehaviorSubject<
-    Quiz<Country> | undefined
+  private _quiz: Quiz<Country> | undefined = undefined;
+  private _stateSubject = new BehaviorSubject<
+    QuizState<Country> | undefined
   >(undefined);
-  quiz$ = this._quizSubject.pipe(
-    map((quiz) => quiz?.state),
+  quiz$ = this._stateSubject.pipe(
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
@@ -26,7 +26,7 @@ export class QuizService {
   ) {
     this._routerService.route$
       .pipe(filter((route) => !route.includes(Route.quiz)))
-      .subscribe(() => this._quizSubject.next(undefined));
+      .subscribe(() => this._stateSubject.next(undefined));
   }
 
   initializeQuiz({ quantity, places }: Selection): void {
@@ -45,16 +45,15 @@ export class QuizService {
         })
       )
       .subscribe((countries) => {
-        this._quizSubject.next(new Quiz(countries));
+        this._quiz = new Quiz(countries);
+        this._stateSubject.next(this._quiz.state);
       });
   }
 
   updateQuiz(correctGuess: boolean): void {
-    this._quizSubject.pipe(first()).subscribe((quiz) => {
-      if (quiz) {
-        quiz.guess(correctGuess);
-        this._quizSubject.next(quiz);
-      }
-    });
+    if (this._quiz) {
+      this._quiz.guess(correctGuess);
+      this._stateSubject.next(this._quiz.state);
+    }
   }
 }

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
@@ -20,10 +20,10 @@ import { Country, QuizType } from '@atocha/globetrotter/types';
 })
 export class QuizCardsComponent implements OnInit {
   @Input() type: QuizType | undefined;
-  @Input() countries: Country[] = [];
+  @Input() countries: readonly Country[] = [];
   @Input() currentCountry: Country | undefined;
   @Output() guessed = new EventEmitter<boolean>();
-  shuffledCountries: Country[] = [];
+  shuffledCountries: readonly Country[] = [];
   canFlipCards = true;
 
   ngOnInit(): void {

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz.component.html
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz.component.html
@@ -2,10 +2,10 @@
   <ng-container *ngIf="vm.quiz">
     <app-quiz-menu
       [type]="vm.type"
-      [guess]="vm.quiz.currentGuess"
+      [guess]="vm.quiz.totalGuesses + 1"
       [correctGuesses]="vm.quiz.correctGuesses"
       [currentCountry]="vm.quiz.currentItem"
-      [totalCountries]="vm.quiz.itemsTotal"
+      [totalCountries]="vm.quiz.items.length"
       [accuracy]="vm.quiz.accuracy"
       [isComplete]="vm.quiz.isComplete"
       (menuReady)="showCards = $event"

--- a/libs/globetrotter/types/src/lib/mappers/map-regions-to-place-selection.spec.ts
+++ b/libs/globetrotter/types/src/lib/mappers/map-regions-to-place-selection.spec.ts
@@ -9,17 +9,14 @@ describe('mapRegionsToPlaceSelection', () => {
         subregions: [
           {
             name: 'North America',
-            region: 'Americas',
             countries: [],
           },
           {
             name: 'Central America',
-            region: 'Americas',
             countries: [],
           },
           {
             name: 'South America',
-            region: 'Americas',
             countries: [],
           },
         ],


### PR DESCRIPTION
1. Simplifies QuizState interface and makes its `items` property readonly
2. Refactors QuizService to push state into the subject rather than the entire quiz class instance
3. Writes .spec for QuizService
4. Removes obsolete keys from mock regions array in mapper test file