### PR TITLE
Universal usage of `trackByFactory` helper

### DIFF
--- a/libs/core/ui/src/lib/tree/tree.component.html
+++ b/libs/core/ui/src/lib/tree/tree.component.html
@@ -8,7 +8,7 @@
 
 <ng-container *ngIf="getChildren(node)?.length">
   <core-tree
-    *ngFor="let child of getChildren(node); trackBy: trackById"
+    *ngFor="let child of getChildren(node); trackBy: trackByFn"
     [node]="child"
     [template]="template ? template : defaultTemplate"
     [level]="level + 1"

--- a/libs/core/ui/src/lib/tree/tree.component.ts
+++ b/libs/core/ui/src/lib/tree/tree.component.ts
@@ -5,8 +5,9 @@ import {
   Input,
   OnInit,
   TemplateRef,
-  TrackByFunction,
 } from '@angular/core';
+
+import { trackByFactory } from '../performance/track-by';
 
 interface TreeNodeContext<T> {
   $implicit: T;
@@ -46,7 +47,8 @@ export class TreeComponent<T> implements OnInit {
    */
   @Input() getChildren: (node: T) => T[] = () => [];
 
-  trackById: TrackByFunction<T> = (index, node) => this.getId(node);
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  trackByFn = trackByFactory(this.getId);
 
   ngOnInit(): void {
     if (!this.node) {

--- a/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.html
+++ b/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.html
@@ -14,7 +14,7 @@
     />
   </div>
   <div class="table">
-    <ui-small-caps *ngFor="let tableDatum of tableData"
+    <ui-small-caps *ngFor="let tableDatum of tableData; trackBy: tableDataTrackByFn"
       class="table-header"
       [header]="tableDatum.header"
       [template]="tableDatum?.template"
@@ -58,7 +58,7 @@
   <ng-template #list
     let-items="items"
   >
-    <span *ngFor="let item of items; last as last">
+    <span *ngFor="let item of items; last as last; trackBy: itemTrackByFn">
       {{ item }}{{ !last ? ',' : '' }}
     </span>
   </ng-template>

--- a/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
+++ b/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
@@ -9,8 +9,8 @@ import {
   ChangeDetectorRef,
   SimpleChanges,
 } from '@angular/core';
-import { trackByFactory, trackBySelf } from '@atocha/core/ui';
 
+import { trackByFactory, trackBySelf } from '@atocha/core/ui';
 import { pluralize } from '@atocha/core/util';
 import { Country } from '@atocha/globetrotter/util';
 

--- a/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
+++ b/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
@@ -38,7 +38,9 @@ export class ExploreCountryComponent implements OnChanges, AfterViewInit {
     | undefined;
   @ViewChild('list') listTemplate: TemplateRef<unknown> | undefined;
   tableData: TableData[] = [];
-  readonly tableDataTrackByFn = trackByFactory<TableData>(({ header }) => header);
+  readonly tableDataTrackByFn = trackByFactory<TableData>(
+    ({ header }) => header
+  );
   readonly itemTrackByFn = trackBySelf;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}

--- a/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
+++ b/libs/globetrotter/feature-explore/src/lib/explore-country/explore-country.component.ts
@@ -9,11 +9,12 @@ import {
   ChangeDetectorRef,
   SimpleChanges,
 } from '@angular/core';
+import { trackByFactory, trackBySelf } from '@atocha/core/ui';
 
 import { pluralize } from '@atocha/core/util';
 import { Country } from '@atocha/globetrotter/util';
 
-interface TableContent {
+interface TableData {
   header: string;
   content?: string;
   template?: TemplateRef<unknown>;
@@ -36,7 +37,9 @@ export class ExploreCountryComponent implements OnChanges, AfterViewInit {
     | TemplateRef<unknown>
     | undefined;
   @ViewChild('list') listTemplate: TemplateRef<unknown> | undefined;
-  tableData: TableContent[] = [];
+  tableData: TableData[] = [];
+  readonly tableDataTrackByFn = trackByFactory<TableData>(({ header }) => header);
+  readonly itemTrackByFn = trackBySelf;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.html
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.html
@@ -2,7 +2,7 @@
   @stagger
 >
   <app-quiz-card
-    *ngFor="let country of shuffledCountries"
+    *ngFor="let country of shuffledCountries; trackBy: trackByFn"
     @fadeIn
     [type]="type"
     [country]="country"

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
@@ -10,6 +10,7 @@ import { shuffle } from 'lodash-es';
 
 import { staggerAnimation, fadeInAnimation } from '@atocha/globetrotter/ui';
 import { Country, QuizType } from '@atocha/globetrotter/util';
+import { trackByFactory } from '@atocha/core/ui';
 
 @Component({
   selector: 'app-quiz-cards',
@@ -25,6 +26,7 @@ export class QuizCardsComponent implements OnInit {
   @Output() guessed = new EventEmitter<boolean>();
   shuffledCountries: readonly Country[] = [];
   canFlipCards = true;
+  readonly trackByFn = trackByFactory<Country>(({ id }) => id);
 
   ngOnInit(): void {
     this.shuffledCountries = shuffle(this.countries);

--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-cards.component.ts
@@ -8,9 +8,9 @@ import {
 } from '@angular/core';
 import { shuffle } from 'lodash-es';
 
+import { trackByFactory } from '@atocha/core/ui';
 import { staggerAnimation, fadeInAnimation } from '@atocha/globetrotter/ui';
 import { Country, QuizType } from '@atocha/globetrotter/util';
-import { trackByFactory } from '@atocha/core/ui';
 
 @Component({
   selector: 'app-quiz-cards',

--- a/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.html
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.html
@@ -21,7 +21,7 @@
   </div>
   <div class="regions">
     <div class="region"
-      *ngFor="let regionState of regionStates"
+      *ngFor="let regionState of regionStates; trackBy: trackByFn"
     >
       <ui-icon class="region__image"
         [icon]="regionState.region.name"

--- a/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/select/select-places/select-places.component.ts
@@ -6,7 +6,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 
-import { CheckboxStates } from '@atocha/core/ui';
+import { CheckboxStates, trackByFactory } from '@atocha/core/ui';
 import {
   Place,
   PlaceSelection,
@@ -52,6 +52,7 @@ export class SelectPlacesComponent {
   regionStates: RegionState[] = [];
   overallSelected = 0;
   overallTotal = 0;
+  readonly trackByFn = trackByFactory<RegionState>(({ region }) => region.name);
   private _allSelectedState: PlaceSelection = {};
 
   getId = ({ name }: Place) => name;

--- a/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.html
+++ b/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.html
@@ -12,7 +12,7 @@
     ></ui-icon>
   </a>
   <a class="link"
-    *ngFor="let link of links"
+    *ngFor="let link of links; trackBy: trackByFn"
     routerLink="/{{link.route}}"
     routerLinkActive="link--active"
     [routerLinkActiveOptions]="{exact: link.exactPathMatch}"

--- a/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.ts
+++ b/libs/globetrotter/feature-shell/src/lib/navigation/navigation.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 
-import { AnimatedComponent } from '@atocha/core/ui';
+import { AnimatedComponent, trackByFactory } from '@atocha/core/ui';
 import { positionAnimation } from '@atocha/globetrotter/ui';
 import { Route } from '@atocha/globetrotter/util';
 
@@ -38,4 +38,5 @@ export class NavigationComponent extends AnimatedComponent {
       exactPathMatch: false,
     },
   ];
+  readonly trackByFn = trackByFactory<NavigationLink>(({ name }) => name);
 }

--- a/libs/globetrotter/ui/src/lib/list-details/list-details.component.ts
+++ b/libs/globetrotter/ui/src/lib/list-details/list-details.component.ts
@@ -19,7 +19,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { AutofocusDirective } from '@atocha/core/ui';
+import { AutofocusDirective, trackByFactory } from '@atocha/core/ui';
 import { InputComponent } from '../input/input.component';
 
 export interface ListDetailsStyles {
@@ -64,12 +64,9 @@ export class ListDetailsComponent<T>
   gap = '12px';
   containerHeight = '';
   toolbarHeight = '';
+  readonly trackByFn = trackByFactory(this.getItemUniqueId);
   private _selectedItemIndex = 0;
   private _listItemHeight = 0;
-
-  trackByFn = (index: number, item: T): string => {
-    return this.getItemUniqueId(item);
-  };
 
   @HostListener('window:keydown.arrowUp', ['$event'])
   onArrowUp(event: KeyboardEvent): void {

--- a/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.html
+++ b/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.html
@@ -2,7 +2,7 @@
   <div class="options" [class.options--stacked]="stacked">
     <div
       class="option"
-      *ngFor="let option of options"
+      *ngFor="let option of options; trackBy: trackByFn"
       [class.option--stacked]="stacked"
     >
       <input

--- a/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
+++ b/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
@@ -36,7 +36,9 @@ export class RadioButtonsComponent<T> implements ControlValueAccessor {
   @Input() options: RadioButtonsOption<T>[] = [];
   @Input() stacked = false;
   model: RadioButtonsOption<T> | undefined;
-  readonly trackByFn = trackByFactory<RadioButtonsOption<T>>(({ display }) => display);
+  readonly trackByFn = trackByFactory<RadioButtonsOption<T>>(
+    ({ display }) => display
+  );
   private _onChangeFn: (model: RadioButtonsOption<T>) => void = () => undefined;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}

--- a/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
+++ b/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
@@ -10,6 +10,7 @@ import {
   FormsModule,
   NG_VALUE_ACCESSOR,
 } from '@angular/forms';
+import { trackByFactory } from '@atocha/core/ui';
 
 export interface RadioButtonsOption<T> {
   display: string;
@@ -35,6 +36,7 @@ export class RadioButtonsComponent<T> implements ControlValueAccessor {
   @Input() options: RadioButtonsOption<T>[] = [];
   @Input() stacked = false;
   model: RadioButtonsOption<T> | undefined;
+  readonly trackByFn = trackByFactory<RadioButtonsOption<T>>(({ display }) => display);
   private _onChangeFn: (model: RadioButtonsOption<T>) => void = () => undefined;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}

--- a/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
+++ b/libs/globetrotter/ui/src/lib/radio-buttons/radio-buttons.component.ts
@@ -10,6 +10,7 @@ import {
   FormsModule,
   NG_VALUE_ACCESSOR,
 } from '@angular/forms';
+
 import { trackByFactory } from '@atocha/core/ui';
 
 export interface RadioButtonsOption<T> {


### PR DESCRIPTION
1. Refactors `TreeComponent` to use helper `trackByFactory`
2. Implements trackBy functions in all globetrotter `*ngFor` statements