### PR TITLE
Bug fix: InlineDaySelectComponent

### DIFF
--- a/libs/menu-matriarch/ui/src/lib/inline-day-select/inline-day-select.component.ts
+++ b/libs/menu-matriarch/ui/src/lib/inline-day-select/inline-day-select.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   Component,
   ChangeDetectionStrategy,
@@ -15,7 +16,7 @@ import { InputComponent } from '../_generic/input/input.component';
 @Component({
   standalone: true,
   selector: 'ui-inline-day-select',
-  imports: [FormsModule, InlineFormComponent, InputComponent],
+  imports: [CommonModule, FormsModule, InlineFormComponent, InputComponent],
   templateUrl: './inline-day-select.component.html',
   styleUrls: ['./inline-day-select.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
`InlineDaySelectComponent` was missing the `CommonModule` import, so it was throwing an error when interacting with the dropdown