### PR TITLE
Privatizes `RouterService`

### DIFF
--- a/apps/menu-matriarch/src/app/app.component.ts
+++ b/apps/menu-matriarch/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import {
   ErrorService,
-  RouterService,
+  LoadingService,
 } from '@atocha/menu-matriarch/data-access';
 
 @Component({
@@ -13,10 +13,10 @@ import {
 })
 export class AppComponent {
   error$ = this._errorService.errors$;
-  loading$ = this._routerService.loading$;
+  loading$ = this._loadingService.loading$;
 
   constructor(
     private _errorService: ErrorService,
-    private _routerService: RouterService
+    private _loadingService: LoadingService
   ) {}
 }

--- a/libs/menu-matriarch/data-access/src/index.ts
+++ b/libs/menu-matriarch/data-access/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/auth.guard';
 export * from './lib/dish.service';
 export * from './lib/error.service';
 export * from './lib/filter.service';
+export * from './lib/loading.service';
 export * from './lib/logged-in-auth.guard';
 export * from './lib/meal.service';
 export * from './lib/menu.service';

--- a/libs/menu-matriarch/data-access/src/index.ts
+++ b/libs/menu-matriarch/data-access/src/index.ts
@@ -9,7 +9,6 @@ export * from './lib/menu.service';
 export * from './lib/planner.guard';
 export * from './lib/planner.service';
 export * from './lib/print.service';
-export * from './lib/router.service';
 export * from './lib/seed-data.service';
 export * from './lib/tag.service';
 export * from './lib/user.service';

--- a/libs/menu-matriarch/data-access/src/index.ts
+++ b/libs/menu-matriarch/data-access/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/logged-in-auth.guard';
 export * from './lib/meal.service';
 export * from './lib/menu.service';
 export * from './lib/planner.guard';
+export * from './lib/planner.service';
 export * from './lib/print.service';
 export * from './lib/router.service';
 export * from './lib/seed-data.service';

--- a/libs/menu-matriarch/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/dish.service.ts
@@ -11,6 +11,8 @@ import { TagService } from './tag.service';
   providedIn: 'root',
 })
 export class DishService {
+  activeDishId$ = this._dishDataService.activeDishId$;
+
   constructor(
     private _authService: AuthService,
     private _dishDataService: DishDataService,

--- a/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
@@ -29,10 +29,6 @@ export class DishDataService {
     private _dataService: DataService
   ) {}
 
-  updateActiveDishId(id: string): void {
-    this._activeDishIdSubject.next(id);
-  }
-
   getDish(id: string): Observable<DishDto | undefined> {
     return this._dataService.getOne<DishDto>(this._endpoint, id);
   }
@@ -71,6 +67,10 @@ export class DishDataService {
 
     await batch.commit();
     return id;
+  }
+
+  updateActiveDishId(id: string): void {
+    this._activeDishIdSubject.next(id);
   }
 
   async updateDish(

--- a/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
 
 import { DataService } from '@atocha/core/data-access';
 import { lower, sort } from '@atocha/core/util';
@@ -17,11 +17,21 @@ import { BatchService } from './batch.service';
 })
 export class DishDataService {
   private _endpoint = Endpoint.dishes;
+  private _activeDishIdSubject = new BehaviorSubject<string>('');
+
+  activeDishId$ = this._activeDishIdSubject.pipe(
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   constructor(
     private _batchService: BatchService,
     private _dataService: DataService
   ) {}
+
+  updateActiveDishId(id: string): void {
+    this._activeDishIdSubject.next(id);
+  }
 
   getDish(id: string): Observable<DishDto | undefined> {
     return this._dataService.getOne<DishDto>(this._endpoint, id);

--- a/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
 
 import { DataService } from '@atocha/core/data-access';
 import { lower, sort } from '@atocha/core/util';
@@ -17,11 +17,21 @@ import { BatchService } from './batch.service';
 })
 export class MealDataService {
   private _endpoint = Endpoint.meals;
+  private _activeMealIdSubject = new BehaviorSubject<string>('');
+
+  activeMealId$ = this._activeMealIdSubject.pipe(
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   constructor(
     private _batchService: BatchService,
     private _dataService: DataService
   ) {}
+
+  updateActiveMealId(id: string): void {
+    this._activeMealIdSubject.next(id);
+  }
 
   getMeal(id: string): Observable<MealDto | undefined> {
     return this._dataService.getOne<MealDto>(this._endpoint, id);

--- a/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
@@ -29,10 +29,6 @@ export class MealDataService {
     private _dataService: DataService
   ) {}
 
-  updateActiveMealId(id: string): void {
-    this._activeMealIdSubject.next(id);
-  }
-
   getMeal(id: string): Observable<MealDto | undefined> {
     return this._dataService.getOne<MealDto>(this._endpoint, id);
   }
@@ -78,6 +74,10 @@ export class MealDataService {
 
     await batch.commit();
     return id;
+  }
+
+  updateActiveMealId(id: string): void {
+    this._activeMealIdSubject.next(id);
   }
 
   async updateMeal(meal: Meal, data: Partial<MealDto>): Promise<void> {

--- a/libs/menu-matriarch/data-access/src/lib/internal/router.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/router.service.ts
@@ -16,9 +16,9 @@ import {
 } from 'rxjs/operators';
 
 import { Route } from '@atocha/menu-matriarch/util';
-import { LocalStateService } from './internal/local-state.service';
-import { MealDataService } from './internal/meal-data.service';
-import { DishDataService } from './internal/dish-data.service';
+import { LocalStateService } from './local-state.service';
+import { MealDataService } from './meal-data.service';
+import { DishDataService } from './dish-data.service';
 
 @Injectable({
   providedIn: 'root',

--- a/libs/menu-matriarch/data-access/src/lib/loading.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/loading.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { RouterService } from './router.service';
+
+import { RouterService } from './internal/router.service';
 
 @Injectable({
   providedIn: 'root',

--- a/libs/menu-matriarch/data-access/src/lib/loading.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/loading.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { RouterService } from './router.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoadingService {
+  loading$ = this._routerService.loading$;
+
+  constructor(private _routerService: RouterService) {}
+}

--- a/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
+++ b/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
@@ -23,14 +23,13 @@ export class LoggedInAuthGuard implements CanActivate {
     | UrlTree {
     return this._authService.loggedIn$.pipe(
       first(),
-      switchMap((loggedIn) => {
-        if (loggedIn) {
-          return this._plannerService.route$.pipe(
-            map((route) => this._router.createUrlTree(route))
-          );
-        }
-        return of(true);
-      })
+      switchMap((loggedIn) =>
+        loggedIn
+          ? this._plannerService.route$.pipe(
+              map((route) => this._router.createUrlTree(route))
+            )
+          : of(true)
+      )
     );
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
+++ b/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
@@ -25,7 +25,7 @@ export class LoggedInAuthGuard implements CanActivate {
       first(),
       switchMap((loggedIn) => {
         if (loggedIn) {
-          return this._plannerService.plannerRoute$.pipe(
+          return this._plannerService.route$.pipe(
             map((route) => this._router.createUrlTree(route))
           );
         }

--- a/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
+++ b/libs/menu-matriarch/data-access/src/lib/logged-in-auth.guard.ts
@@ -4,7 +4,7 @@ import { Observable, of } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
-import { RouterService } from './router.service';
+import { PlannerService } from './planner.service';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +13,7 @@ export class LoggedInAuthGuard implements CanActivate {
   constructor(
     private _router: Router,
     private _authService: AuthService,
-    private _routerService: RouterService
+    private _plannerService: PlannerService
   ) {}
 
   canActivate():
@@ -25,7 +25,7 @@ export class LoggedInAuthGuard implements CanActivate {
       first(),
       switchMap((loggedIn) => {
         if (loggedIn) {
-          return this._routerService.plannerRoute$.pipe(
+          return this._plannerService.plannerRoute$.pipe(
             map((route) => this._router.createUrlTree(route))
           );
         }

--- a/libs/menu-matriarch/data-access/src/lib/meal.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/meal.service.ts
@@ -12,6 +12,8 @@ import { TagService } from './tag.service';
   providedIn: 'root',
 })
 export class MealService {
+  activeMealId$ = this._mealDataService.activeMealId$;
+
   constructor(
     private _authService: AuthService,
     private _dishService: DishService,

--- a/libs/menu-matriarch/data-access/src/lib/planner.guard.ts
+++ b/libs/menu-matriarch/data-access/src/lib/planner.guard.ts
@@ -19,7 +19,7 @@ export class PlannerGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._plannerService.plannerRoute$.pipe(
+    return this._plannerService.route$.pipe(
       first(),
       map((route) =>
         route.length > 1 ? this._router.createUrlTree(route) : true

--- a/libs/menu-matriarch/data-access/src/lib/planner.guard.ts
+++ b/libs/menu-matriarch/data-access/src/lib/planner.guard.ts
@@ -3,20 +3,23 @@ import { CanActivate, Router, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 
-import { RouterService } from './router.service';
+import { PlannerService } from './planner.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PlannerGuard implements CanActivate {
-  constructor(private _router: Router, private _routerService: RouterService) {}
+  constructor(
+    private _router: Router,
+    private _plannerService: PlannerService
+  ) {}
 
   canActivate():
     | Observable<boolean | UrlTree>
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this._routerService.plannerRoute$.pipe(
+    return this._plannerService.plannerRoute$.pipe(
       first(),
       map((route) =>
         route.length > 1 ? this._router.createUrlTree(route) : true

--- a/libs/menu-matriarch/data-access/src/lib/planner.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/planner.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
+
+import { PlannerView, Route } from '@atocha/menu-matriarch/util';
+import { LocalStateService } from './internal/local-state.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PlannerService {
+  constructor(private _localStateService: LocalStateService) {}
+
+  activePlannerView$ = this._localStateService.plannerView$;
+
+  plannerRoute$ = this._localStateService.menuId$.pipe(
+    map((menuId) => (menuId ? [Route.planner, menuId] : [Route.planner])),
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  updatePlannerView(view: PlannerView): void {
+    this._localStateService.updatePlannerView(view);
+  }
+}

--- a/libs/menu-matriarch/data-access/src/lib/planner.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/planner.service.ts
@@ -10,15 +10,15 @@ import { LocalStateService } from './internal/local-state.service';
 export class PlannerService {
   constructor(private _localStateService: LocalStateService) {}
 
-  activePlannerView$ = this._localStateService.plannerView$;
-
-  plannerRoute$ = this._localStateService.menuId$.pipe(
+  route$ = this._localStateService.menuId$.pipe(
     map((menuId) => (menuId ? [Route.planner, menuId] : [Route.planner])),
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  updatePlannerView(view: PlannerView): void {
+  view$ = this._localStateService.plannerView$;
+
+  updateView(view: PlannerView): void {
     this._localStateService.updatePlannerView(view);
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/router.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/router.service.ts
@@ -17,6 +17,8 @@ import {
 
 import { Route } from '@atocha/menu-matriarch/util';
 import { LocalStateService } from './internal/local-state.service';
+import { MealDataService } from './internal/meal-data.service';
+import { DishDataService } from './internal/dish-data.service';
 
 @Injectable({
   providedIn: 'root',
@@ -34,13 +36,11 @@ export class RouterService {
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  // DishDataService
   activeDishId$ = this._activeDishId$.pipe(
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  // MealDataService
   activeMealId$ = this._activeMealId$.pipe(
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
@@ -48,7 +48,9 @@ export class RouterService {
 
   constructor(
     private _router: Router,
-    private _localStateService: LocalStateService
+    private _dishDataService: DishDataService,
+    private _localStateService: LocalStateService,
+    private _mealDataService: MealDataService
   ) {
     this._routerEvents$
       .pipe(
@@ -86,6 +88,7 @@ export class RouterService {
           const divviedUrl = event.urlAfterRedirects.split('/');
           const mealId = divviedUrl[2];
           this._activeMealId$.next(mealId ?? '');
+          this._mealDataService.updateActiveMealId(mealId ?? '');
         })
       )
       .subscribe();
@@ -97,6 +100,7 @@ export class RouterService {
           const divviedUrl = event.urlAfterRedirects.split('/');
           const dishId = divviedUrl[2];
           this._activeDishId$.next(dishId ?? '');
+          this._dishDataService.updateActiveDishId(dishId ?? '');
         })
       )
       .subscribe();

--- a/libs/menu-matriarch/data-access/src/lib/router.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/router.service.ts
@@ -25,23 +25,11 @@ import { DishDataService } from './internal/dish-data.service';
 })
 export class RouterService {
   private _loading$ = new BehaviorSubject<boolean>(true);
-  private _activeDishId$ = new BehaviorSubject<string>('');
-  private _activeMealId$ = new BehaviorSubject<string>('');
   private _routerEvents$ = this._router.events.pipe(
     filter((e): e is NavigationEnd => e instanceof NavigationEnd)
   );
 
   loading$ = this._loading$.pipe(
-    distinctUntilChanged(),
-    shareReplay({ bufferSize: 1, refCount: true })
-  );
-
-  activeDishId$ = this._activeDishId$.pipe(
-    distinctUntilChanged(),
-    shareReplay({ bufferSize: 1, refCount: true })
-  );
-
-  activeMealId$ = this._activeMealId$.pipe(
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
@@ -87,7 +75,6 @@ export class RouterService {
         tap((event) => {
           const divviedUrl = event.urlAfterRedirects.split('/');
           const mealId = divviedUrl[2];
-          this._activeMealId$.next(mealId ?? '');
           this._mealDataService.updateActiveMealId(mealId ?? '');
         })
       )
@@ -99,7 +86,6 @@ export class RouterService {
         tap((event) => {
           const divviedUrl = event.urlAfterRedirects.split('/');
           const dishId = divviedUrl[2];
-          this._activeDishId$.next(dishId ?? '');
           this._dishDataService.updateActiveDishId(dishId ?? '');
         })
       )

--- a/libs/menu-matriarch/data-access/src/lib/router.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/router.service.ts
@@ -34,16 +34,19 @@ export class RouterService {
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
+  // DishDataService
   activeDishId$ = this._activeDishId$.pipe(
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
+  // MealDataService
   activeMealId$ = this._activeMealId$.pipe(
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
+  // PlannerService
   activePlannerView$ = this._localStateService.plannerView$;
 
   plannerRoute$ = this._localStateService.menuId$.pipe(

--- a/libs/menu-matriarch/data-access/src/lib/router.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/router.service.ts
@@ -15,7 +15,7 @@ import {
   shareReplay,
 } from 'rxjs/operators';
 
-import { PlannerView, Route } from '@atocha/menu-matriarch/util';
+import { Route } from '@atocha/menu-matriarch/util';
 import { LocalStateService } from './internal/local-state.service';
 
 @Injectable({
@@ -42,15 +42,6 @@ export class RouterService {
 
   // MealDataService
   activeMealId$ = this._activeMealId$.pipe(
-    distinctUntilChanged(),
-    shareReplay({ bufferSize: 1, refCount: true })
-  );
-
-  // PlannerService
-  activePlannerView$ = this._localStateService.plannerView$;
-
-  plannerRoute$ = this._localStateService.menuId$.pipe(
-    map((menuId) => (menuId ? [Route.planner, menuId] : [Route.planner])),
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
@@ -109,9 +100,5 @@ export class RouterService {
         })
       )
       .subscribe();
-  }
-
-  updatePlannerView(view: PlannerView): void {
-    this._localStateService.updatePlannerView(view);
   }
 }

--- a/libs/menu-matriarch/feature-entities/src/lib/dishes-list/dishes-list.component.ts
+++ b/libs/menu-matriarch/feature-entities/src/lib/dishes-list/dishes-list.component.ts
@@ -13,7 +13,6 @@ import { map } from 'rxjs/operators';
 import {
   DishService,
   FilterService,
-  RouterService,
   TagService,
 } from '@atocha/menu-matriarch/data-access';
 import { dishTrackByFn, groupTrackByFn } from '@atocha/menu-matriarch/ui';
@@ -31,7 +30,7 @@ export class DishesListComponent {
     this._dishService.getDishes(),
     this._tagService.getTags(),
     this._filterService.state$,
-    this._routerService.activeDishId$,
+    this._dishService.activeDishId$,
   ]).pipe(
     map(([dishes, tags, { text, tagIds, panel }, activeDishId]) => {
       const activeDish = dishes.find((dish) => dish.id === activeDishId);
@@ -68,7 +67,6 @@ export class DishesListComponent {
   constructor(
     private _dishService: DishService,
     private _filterService: FilterService,
-    private _routerService: RouterService,
     private _router: Router,
     private _tagService: TagService
   ) {}

--- a/libs/menu-matriarch/feature-entities/src/lib/meals-list/meals-list.component.ts
+++ b/libs/menu-matriarch/feature-entities/src/lib/meals-list/meals-list.component.ts
@@ -15,7 +15,6 @@ import { Meal } from '@atocha/menu-matriarch/util';
 import {
   FilterService,
   MealService,
-  RouterService,
   TagService,
   UserService,
 } from '@atocha/menu-matriarch/data-access';
@@ -34,7 +33,7 @@ export class MealsListComponent {
     this._tagService.getTags(),
     this._userService.getPreferences(),
     this._filterService.state$,
-    this._routerService.activeMealId$,
+    this._mealService.activeMealId$,
   ]).pipe(
     map(([meals, tags, preferences, { text, tagIds, panel }, activeMealId]) => {
       const filteredMeals = this._filterService.filterMeals({
@@ -66,7 +65,6 @@ export class MealsListComponent {
   constructor(
     private _filterService: FilterService,
     private _mealService: MealService,
-    private _routerService: RouterService,
     private _router: Router,
     private _tagService: TagService,
     private _userService: UserService

--- a/libs/menu-matriarch/feature-planner/src/lib/planner.component.html
+++ b/libs/menu-matriarch/feature-planner/src/lib/planner.component.html
@@ -4,12 +4,12 @@
       <app-planner-dishes class="left"
         *ngIf="view === 'dishes'"
         [menu]="menu"
-        (nameDblClick)="updatePlannerView('meals')"
+        (nameDblClick)="updateView('meals')"
       ></app-planner-dishes>
       <app-planner-meals class="left"
         *ngIf="view === 'meals'"
         [menu]="menu"
-        (nameDblClick)="updatePlannerView('dishes')"
+        (nameDblClick)="updateView('dishes')"
       ></app-planner-meals>
     </ng-container>
     <app-planner-menu class="right"

--- a/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
+++ b/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
@@ -3,7 +3,11 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
-import { MenuService, RouterService } from '@atocha/menu-matriarch/data-access';
+import {
+  MenuService,
+  PlannerService,
+  RouterService,
+} from '@atocha/menu-matriarch/data-access';
 import { PlannerView } from '@atocha/menu-matriarch/util';
 
 @Component({
@@ -28,10 +32,11 @@ export class PlannerComponent {
   constructor(
     private _route: ActivatedRoute,
     private _menuService: MenuService,
+    private _plannerService: PlannerService,
     private _routerService: RouterService
   ) {}
 
   updatePlannerView(view: PlannerView): void {
-    this._routerService.updatePlannerView(view);
+    this._plannerService.updatePlannerView(view);
   }
 }

--- a/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
+++ b/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
@@ -6,7 +6,6 @@ import { map, switchMap } from 'rxjs/operators';
 import {
   MenuService,
   PlannerService,
-  RouterService,
 } from '@atocha/menu-matriarch/data-access';
 import { PlannerView } from '@atocha/menu-matriarch/util';
 
@@ -17,7 +16,7 @@ import { PlannerView } from '@atocha/menu-matriarch/util';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlannerComponent {
-  view$ = this._routerService.activePlannerView$;
+  view$ = this._plannerService.activePlannerView$;
   menu$ = this._route.paramMap.pipe(
     map((paramMap) => paramMap.get('menuId')),
     switchMap((menuId) => {
@@ -32,8 +31,7 @@ export class PlannerComponent {
   constructor(
     private _route: ActivatedRoute,
     private _menuService: MenuService,
-    private _plannerService: PlannerService,
-    private _routerService: RouterService
+    private _plannerService: PlannerService
   ) {}
 
   updatePlannerView(view: PlannerView): void {

--- a/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
+++ b/libs/menu-matriarch/feature-planner/src/lib/planner.component.ts
@@ -16,7 +16,7 @@ import { PlannerView } from '@atocha/menu-matriarch/util';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlannerComponent {
-  view$ = this._plannerService.activePlannerView$;
+  view$ = this._plannerService.view$;
   menu$ = this._route.paramMap.pipe(
     map((paramMap) => paramMap.get('menuId')),
     switchMap((menuId) => {
@@ -34,7 +34,7 @@ export class PlannerComponent {
     private _plannerService: PlannerService
   ) {}
 
-  updatePlannerView(view: PlannerView): void {
-    this._plannerService.updatePlannerView(view);
+  updateView(view: PlannerView): void {
+    this._plannerService.updateView(view);
   }
 }

--- a/libs/menu-matriarch/feature-shell/src/lib/header/header.component.ts
+++ b/libs/menu-matriarch/feature-shell/src/lib/header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { PlannerService } from '@atocha/menu-matriarch/data-access';
 
 import { Route } from '@atocha/menu-matriarch/util';
-import { RouterService } from '@atocha/menu-matriarch/data-access';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -12,7 +12,7 @@ import { RouterService } from '@atocha/menu-matriarch/data-access';
 })
 export class HeaderComponent {
   Route: typeof Route = Route;
-  plannerRoute$ = this._routerService.plannerRoute$;
+  plannerRoute$ = this._plannerService.plannerRoute$;
 
-  constructor(private _routerService: RouterService) {}
+  constructor(private _plannerService: PlannerService) {}
 }

--- a/libs/menu-matriarch/feature-shell/src/lib/header/header.component.ts
+++ b/libs/menu-matriarch/feature-shell/src/lib/header/header.component.ts
@@ -12,7 +12,7 @@ import { Route } from '@atocha/menu-matriarch/util';
 })
 export class HeaderComponent {
   Route: typeof Route = Route;
-  plannerRoute$ = this._plannerService.plannerRoute$;
+  plannerRoute$ = this._plannerService.route$;
 
   constructor(private _plannerService: PlannerService) {}
 }

--- a/libs/menu-matriarch/feature-shell/src/lib/welcome/welcome.component.ts
+++ b/libs/menu-matriarch/feature-shell/src/lib/welcome/welcome.component.ts
@@ -44,7 +44,7 @@ export class WelcomeComponent {
           )
           .subscribe();
       } else {
-        this._plannerService.plannerRoute$
+        this._plannerService.route$
           .pipe(tap((route) => this._router.navigate(route)))
           .subscribe();
       }

--- a/libs/menu-matriarch/feature-shell/src/lib/welcome/welcome.component.ts
+++ b/libs/menu-matriarch/feature-shell/src/lib/welcome/welcome.component.ts
@@ -4,7 +4,7 @@ import { first, tap } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
 import {
-  RouterService,
+  PlannerService,
   SeedDataService,
 } from '@atocha/menu-matriarch/data-access';
 
@@ -18,7 +18,7 @@ export class WelcomeComponent {
   constructor(
     private _router: Router,
     private _authService: AuthService,
-    private _routerService: RouterService,
+    private _plannerService: PlannerService,
     private _seedDataService: SeedDataService
   ) {}
 
@@ -44,7 +44,7 @@ export class WelcomeComponent {
           )
           .subscribe();
       } else {
-        this._routerService.plannerRoute$
+        this._plannerService.plannerRoute$
           .pipe(tap((route) => this._router.navigate(route)))
           .subscribe();
       }


### PR DESCRIPTION
1. Moves `activeDishId$` and `activeMealId$` members out of `RouterService` and into respective data services
2. Creates `PlannerService` and moves relevant class members to there from `RouterService`
3. Updates references to point (mostly) away from `RouterService` and relocates file to `_internal` inside MM `data-access` lib

Resolves #148 