### PR TITLE
Global renaming of selector prefix: "atocha" to "app"

### DIFF
--- a/apps/lorenzo/project.json
+++ b/apps/lorenzo/project.json
@@ -1,7 +1,7 @@
 {
   "projectType": "application",
   "sourceRoot": "apps/lorenzo/src",
-  "prefix": "atocha",
+  "prefix": "app",
   "targets": {
     "build": {
       "executor": "@angular-devkit/build-angular:browser",

--- a/libs/core/data-access/.eslintrc.json
+++ b/libs/core/data-access/.eslintrc.json
@@ -13,7 +13,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "atocha",
+            "prefix": "app",
             "style": "camelCase"
           }
         ],
@@ -21,7 +21,7 @@
           "error",
           {
             "type": "element",
-            "prefix": "atocha",
+            "prefix": "app",
             "style": "kebab-case"
           }
         ]

--- a/libs/core/data-access/project.json
+++ b/libs/core/data-access/project.json
@@ -2,7 +2,7 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/core/data-access/src",
-  "prefix": "atocha",
+  "prefix": "app",
   "targets": {
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/libs/globetrotter/feature-explore/project.json
+++ b/libs/globetrotter/feature-explore/project.json
@@ -1,7 +1,7 @@
 {
   "projectType": "library",
   "sourceRoot": "libs/globetrotter/feature-explore/src",
-  "prefix": "atocha",
+  "prefix": "app",
   "targets": {
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/libs/menu-matriarch/data-access/.eslintrc.json
+++ b/libs/menu-matriarch/data-access/.eslintrc.json
@@ -13,7 +13,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "atocha",
+            "prefix": "app",
             "style": "camelCase"
           }
         ],
@@ -21,7 +21,7 @@
           "error",
           {
             "type": "element",
-            "prefix": "atocha",
+            "prefix": "app",
             "style": "kebab-case"
           }
         ]

--- a/libs/menu-matriarch/data-access/project.json
+++ b/libs/menu-matriarch/data-access/project.json
@@ -1,7 +1,7 @@
 {
   "projectType": "library",
   "sourceRoot": "libs/menu-matriarch/data-access/src",
-  "prefix": "atocha",
+  "prefix": "app",
   "targets": {
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/libs/menu-matriarch/feature-tags/project.json
+++ b/libs/menu-matriarch/feature-tags/project.json
@@ -1,7 +1,7 @@
 {
   "projectType": "library",
   "sourceRoot": "libs/menu-matriarch/feature-tags/src",
-  "prefix": "atocha",
+  "prefix": "app",
   "targets": {
     "test": {
       "executor": "@nrwl/jest:jest",


### PR DESCRIPTION
This should have been set as "app" in multiple libs but was left as the default "atocha" by mistake