### PR TITLE
Makes MM services stricter

### DIFF
--- a/libs/menu-matriarch/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/dish.service.ts
@@ -71,11 +71,11 @@ export class DishService {
     );
   }
 
-  updateDish(dish: Dish, data: EditableDishData): Promise<void> {
+  async updateDish(dish: Dish, data: EditableDishData): Promise<void> {
     return this._dishDataService.updateDish(dish, data);
   }
 
-  deleteDish(dish: Dish): Promise<void> {
+  async deleteDish(dish: Dish): Promise<void> {
     return this._dishDataService.deleteDish(dish);
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/dish.service.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@angular/core';
 import { combineLatest, Observable, of } from 'rxjs';
-import { concatMap, first, map, tap } from 'rxjs/operators';
+import { concatMap, first, map } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
-import { Dish, DishDto, mapDishDtoToDish } from '@atocha/menu-matriarch/util';
-import { DishDataService } from './internal/dish-data.service';
+import { Dish, mapDishDtoToDish } from '@atocha/menu-matriarch/util';
+import {
+  DishDataService,
+  EditableDishData,
+} from './internal/dish-data.service';
 import { RouterService } from './internal/router.service';
 import { TagService } from './tag.service';
 
@@ -54,14 +57,12 @@ export class DishService {
     );
   }
 
-  createDish(
-    dish: Partial<Omit<DishDto, 'id' | 'uid'>>
-  ): Observable<string | undefined> {
+  createDish(dish: EditableDishData): Observable<string | undefined> {
     return this._authService.uid$.pipe(
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._dishDataService.createDish({ uid, dish });
+          const id = await this._dishDataService.createDish(uid, dish);
           return id;
         } else {
           return undefined;
@@ -70,30 +71,11 @@ export class DishService {
     );
   }
 
-  updateDish(
-    id: string,
-    data: Partial<Omit<DishDto, 'usages' | 'menus'>>
-  ): Observable<Dish | undefined> {
-    return this.getDish(id).pipe(
-      first(),
-      tap(async (dish) => {
-        if (!dish) {
-          return;
-        }
-        await this._dishDataService.updateDish(dish, data);
-      })
-    );
+  updateDish(dish: Dish, data: EditableDishData): Promise<void> {
+    return this._dishDataService.updateDish(dish, data);
   }
 
-  deleteDish(id: string): Observable<Dish | undefined> {
-    return this.getDish(id).pipe(
-      first(),
-      tap(async (dish) => {
-        if (!dish) {
-          return;
-        }
-        await this._dishDataService.deleteDish(dish);
-      })
-    );
+  deleteDish(dish: Dish): Promise<void> {
+    return this._dishDataService.deleteDish(dish);
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/dish-data.service.ts
@@ -12,6 +12,11 @@ import {
 } from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
+export type EditableDishData = Pick<
+  DishDto,
+  'name' | 'description' | 'link' | 'tagIds' | 'notes'
+>;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -33,13 +38,7 @@ export class DishDataService {
       .pipe(map((dishDtos) => sort(dishDtos, ({ name }) => lower(name))));
   }
 
-  async createDish({
-    uid,
-    dish,
-  }: {
-    uid: string;
-    dish: Partial<Omit<DishDto, 'id' | 'uid'>>;
-  }): Promise<string> {
+  async createDish(uid: string, dish: EditableDishData): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -63,10 +62,7 @@ export class DishDataService {
     return id;
   }
 
-  async updateDish(
-    dish: Dish,
-    data: Partial<Omit<DishDto, 'usages' | 'menus'>>
-  ): Promise<void> {
+  async updateDish(dish: Dish, data: EditableDishData): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.update({

--- a/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/meal-data.service.ts
@@ -12,6 +12,11 @@ import {
 } from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
+export type EditableMealData = Pick<
+  MealDto,
+  'name' | 'description' | 'dishIds' | 'tagIds'
+>;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -33,10 +38,7 @@ export class MealDataService {
       .pipe(map((mealDtos) => sort(mealDtos, ({ name }) => lower(name))));
   }
 
-  async createMeal(
-    uid: string,
-    meal: Partial<Omit<MealDto, 'id' | 'uid'>>
-  ): Promise<string> {
+  async createMeal(uid: string, meal: EditableMealData): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -70,7 +72,7 @@ export class MealDataService {
     return id;
   }
 
-  async updateMeal(meal: Meal, data: Partial<MealDto>): Promise<void> {
+  async updateMeal(meal: Meal, data: EditableMealData): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.update({

--- a/libs/menu-matriarch/data-access/src/lib/internal/menu-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/menu-data.service.ts
@@ -36,25 +36,16 @@ export class MenuDataService {
       .pipe(map((menuDtos) => sort(menuDtos, ({ name }) => lower(name))));
   }
 
-  async createMenu({
-    uid,
-    menu,
-    startDay,
-  }: {
-    uid: string;
-    menu: EditableMenuData;
-    startDay: Day;
-  }): Promise<string> {
+  async createMenu(uid: string, menu: EditableMenuData): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create<MenuDto>(
       this._endpoint,
       id,
       createMenuDto({
-        ...menu,
         id,
         uid,
-        startDay,
+        ...menu,
       })
     );
 

--- a/libs/menu-matriarch/data-access/src/lib/internal/menu-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/menu-data.service.ts
@@ -13,6 +13,8 @@ import {
 } from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
+export type EditableMenuData = Partial<Pick<MenuDto, 'name' | 'startDay'>>;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -40,7 +42,7 @@ export class MenuDataService {
     startDay,
   }: {
     uid: string;
-    menu: Partial<Omit<MenuDto, 'id' | 'uid' | 'startDay'>>;
+    menu: EditableMenuData;
     startDay: Day;
   }): Promise<string> {
     const id = this._dataService.createId();
@@ -59,7 +61,7 @@ export class MenuDataService {
     return id;
   }
 
-  async updateMenu(id: string, data: Partial<MenuDto>): Promise<void> {
+  async updateMenu(id: string, data: EditableMenuData): Promise<void> {
     return await this._dataService.update<MenuDto>(this._endpoint, id, data);
   }
 

--- a/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
@@ -4,12 +4,7 @@ import { map } from 'rxjs/operators';
 
 import { DataService } from '@atocha/core/data-access';
 import { lower, sort } from '@atocha/core/util';
-import {
-  Tag,
-  TagDto,
-  Endpoint,
-  createTagDto,
-} from '@atocha/menu-matriarch/util';
+import { TagDto, Endpoint, createTagDto } from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
 @Injectable({
@@ -33,13 +28,7 @@ export class TagDataService {
       .pipe(map((tags) => sort(tags, ({ name }) => lower(name))));
   }
 
-  async createTag({
-    uid,
-    tag,
-  }: {
-    uid: string;
-    tag: Partial<Omit<TagDto, 'id' | 'uid'>>;
-  }): Promise<string> {
+  async createTag(uid: string, tag: Pick<TagDto, 'name'>): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create<TagDto>(
@@ -51,11 +40,11 @@ export class TagDataService {
     return id;
   }
 
-  updateTag(id: string, data: Partial<TagDto>): Promise<void> {
+  updateTag(id: string, data: Pick<TagDto, 'name'>): Promise<void> {
     return this._dataService.update<TagDto>(this._endpoint, id, data);
   }
 
-  async deleteTag(tag: Tag): Promise<void> {
+  async deleteTag(tag: TagDto): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, tag.id).updateMultiple([

--- a/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
@@ -12,6 +12,8 @@ import {
 } from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
+export type EditableTagData = Pick<TagDto, 'name'>;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -33,7 +35,7 @@ export class TagDataService {
       .pipe(map((tags) => sort(tags, ({ name }) => lower(name))));
   }
 
-  async createTag(uid: string, tag: Pick<Tag, 'name'>): Promise<string> {
+  async createTag(uid: string, tag: EditableTagData): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create<TagDto>(
@@ -45,8 +47,8 @@ export class TagDataService {
     return id;
   }
 
-  updateTag(id: string, data: Pick<Tag, 'name'>): Promise<void> {
-    return this._dataService.update<TagDto>(this._endpoint, id, data);
+  async updateTag(tag: Tag, data: EditableTagData): Promise<void> {
+    return this._dataService.update<TagDto>(this._endpoint, tag.id, data);
   }
 
   async deleteTag(tag: Tag): Promise<void> {

--- a/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/tag-data.service.ts
@@ -4,7 +4,12 @@ import { map } from 'rxjs/operators';
 
 import { DataService } from '@atocha/core/data-access';
 import { lower, sort } from '@atocha/core/util';
-import { TagDto, Endpoint, createTagDto } from '@atocha/menu-matriarch/util';
+import {
+  Tag,
+  TagDto,
+  Endpoint,
+  createTagDto,
+} from '@atocha/menu-matriarch/util';
 import { BatchService } from './batch.service';
 
 @Injectable({
@@ -18,17 +23,17 @@ export class TagDataService {
     private _dataService: DataService
   ) {}
 
-  getTag(id: string): Observable<TagDto | undefined> {
+  getTag(id: string): Observable<Tag | undefined> {
     return this._dataService.getOne<TagDto>(this._endpoint, id);
   }
 
-  getTags(uid: string): Observable<TagDto[]> {
+  getTags(uid: string): Observable<Tag[]> {
     return this._dataService
       .getMany<TagDto>(this._endpoint, uid)
       .pipe(map((tags) => sort(tags, ({ name }) => lower(name))));
   }
 
-  async createTag(uid: string, tag: Pick<TagDto, 'name'>): Promise<string> {
+  async createTag(uid: string, tag: Pick<Tag, 'name'>): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create<TagDto>(
@@ -40,11 +45,11 @@ export class TagDataService {
     return id;
   }
 
-  updateTag(id: string, data: Pick<TagDto, 'name'>): Promise<void> {
+  updateTag(id: string, data: Pick<Tag, 'name'>): Promise<void> {
     return this._dataService.update<TagDto>(this._endpoint, id, data);
   }
 
-  async deleteTag(tag: TagDto): Promise<void> {
+  async deleteTag(tag: Tag): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, tag.id).updateMultiple([

--- a/libs/menu-matriarch/data-access/src/lib/internal/user-data.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/internal/user-data.service.ts
@@ -26,7 +26,7 @@ export class UserDataService {
     return this.getUser(uid).pipe(map((user) => user?.preferences));
   }
 
-  updatePreferences(
+  async updatePreferences(
     { uid, preferences }: User,
     data: Partial<UserPreferences>
   ): Promise<void> {

--- a/libs/menu-matriarch/data-access/src/lib/meal.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/meal.service.ts
@@ -76,27 +76,11 @@ export class MealService {
     );
   }
 
-  updateMeal(id: string, data: Partial<MealDto>): Observable<Meal | undefined> {
-    return this.getMeal(id).pipe(
-      first(),
-      tap(async (meal) => {
-        if (!meal) {
-          return;
-        }
-        await this._mealDataService.updateMeal(meal, data);
-      })
-    );
+  async updateMeal(meal: Meal, data: Partial<MealDto>): Promise<void> {
+    return this._mealDataService.updateMeal(meal, data);
   }
 
-  deleteMeal(id: string): Observable<Meal | undefined> {
-    return this.getMeal(id).pipe(
-      first(),
-      tap(async (meal) => {
-        if (!meal) {
-          return;
-        }
-        await this._mealDataService.deleteMeal(meal);
-      })
-    );
+  async deleteMeal(meal: Meal): Promise<void> {
+    return this._mealDataService.deleteMeal(meal);
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/meal.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/meal.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@angular/core';
 import { combineLatest, Observable, of } from 'rxjs';
-import { concatMap, first, map, tap } from 'rxjs/operators';
+import { concatMap, first, map } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
-import { MealDto, Meal, mapMealDtoToMeal } from '@atocha/menu-matriarch/util';
+import { Meal, mapMealDtoToMeal } from '@atocha/menu-matriarch/util';
 import { DishService } from './dish.service';
-import { MealDataService } from './internal/meal-data.service';
+import {
+  EditableMealData,
+  MealDataService,
+} from './internal/meal-data.service';
 import { RouterService } from './internal/router.service';
 import { TagService } from './tag.service';
 
@@ -60,9 +63,7 @@ export class MealService {
     );
   }
 
-  createMeal(
-    meal: Partial<Omit<MealDto, 'id' | 'uid'>>
-  ): Observable<string | undefined> {
+  createMeal(meal: EditableMealData): Observable<string | undefined> {
     return this._authService.uid$.pipe(
       first(),
       concatMap(async (uid) => {
@@ -76,7 +77,7 @@ export class MealService {
     );
   }
 
-  async updateMeal(meal: Meal, data: Partial<MealDto>): Promise<void> {
+  async updateMeal(meal: Meal, data: EditableMealData): Promise<void> {
     return this._mealDataService.updateMeal(meal, data);
   }
 

--- a/libs/menu-matriarch/data-access/src/lib/menu.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/menu.service.ts
@@ -66,14 +66,13 @@ export class MenuService {
     );
   }
 
-  createMenu(menu: EditableMenuData): Observable<string | undefined> {
+  createMenu({ name }: EditableMenuData): Observable<string | undefined> {
     return this._userService.getUser().pipe(
       first(),
       concatMap(async (user) => {
         if (user) {
-          const id = await this._menuDataService.createMenu({
-            uid: user.uid,
-            menu,
+          const id = await this._menuDataService.createMenu(user.uid, {
+            name,
             startDay: user.preferences.defaultMenuStartDay,
           });
           return id;

--- a/libs/menu-matriarch/data-access/src/lib/menu.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/menu.service.ts
@@ -1,16 +1,14 @@
 import { Injectable } from '@angular/core';
 import { combineLatest, Observable, of } from 'rxjs';
-import { concatMap, first, map, tap } from 'rxjs/operators';
+import { concatMap, first, map } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
-import {
-  Day,
-  Menu,
-  MenuDto,
-  mapMenuDtoToMenu,
-} from '@atocha/menu-matriarch/util';
+import { Day, Menu, mapMenuDtoToMenu } from '@atocha/menu-matriarch/util';
 import { DishService } from './dish.service';
-import { MenuDataService } from './internal/menu-data.service';
+import {
+  EditableMenuData,
+  MenuDataService,
+} from './internal/menu-data.service';
 import { RouterService } from './internal/router.service';
 import { UserService } from './user.service';
 
@@ -68,9 +66,7 @@ export class MenuService {
     );
   }
 
-  createMenu(
-    menu: Partial<Omit<MenuDto, 'id' | 'uid' | 'startDay'>>
-  ): Observable<string | undefined> {
+  createMenu(menu: EditableMenuData): Observable<string | undefined> {
     return this._userService.getUser().pipe(
       first(),
       concatMap(async (user) => {
@@ -88,15 +84,15 @@ export class MenuService {
     );
   }
 
-  updateMenuName(id: string, name: string): Promise<void> {
+  async updateMenuName(id: string, name: string): Promise<void> {
     return this._menuDataService.updateMenu(id, { name });
   }
 
-  updateMenuStartDay(id: string, startDay: Day): Promise<void> {
+  async updateMenuStartDay(id: string, startDay: Day): Promise<void> {
     return this._menuDataService.updateMenu(id, { startDay });
   }
 
-  updateMenuContents({
+  async updateMenuContents({
     menu,
     day,
     dishIds,
@@ -115,23 +111,11 @@ export class MenuService {
     });
   }
 
-  async deleteMenu(id?: string): Promise<void> {
-    if (id) {
-      this.getMenu(id)
-        .pipe(
-          first(),
-          tap(async (menu) => {
-            if (!menu) {
-              return;
-            }
-            await this._menuDataService.deleteMenu(menu);
-          })
-        )
-        .subscribe();
-    }
+  async deleteMenu(menu: Menu): Promise<void> {
+    return this._menuDataService.deleteMenu(menu);
   }
 
-  deleteMenuContents(menu: Menu, day?: Day): Promise<void> {
+  async deleteMenuContents(menu: Menu, day?: Day): Promise<void> {
     return this._menuDataService.deleteMenuContents(menu, day);
   }
 }

--- a/libs/menu-matriarch/data-access/src/lib/tag.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/tag.service.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 import { concatMap, first, tap } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
-import { Tag, TagDto } from '@atocha/menu-matriarch/util';
+import { Tag } from '@atocha/menu-matriarch/util';
 import { TagDataService } from './internal/tag-data.service';
 
 @Injectable({
@@ -31,14 +31,12 @@ export class TagService {
     );
   }
 
-  createTag(
-    tag: Partial<Omit<TagDto, 'id' | 'uid'>>
-  ): Observable<string | undefined> {
+  createTag(tag: Pick<Tag, 'name'>): Observable<string | undefined> {
     return this._authService.uid$.pipe(
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._tagDataService.createTag({ uid, tag });
+          const id = await this._tagDataService.createTag(uid, tag);
           return id;
         } else {
           return undefined;
@@ -47,7 +45,7 @@ export class TagService {
     );
   }
 
-  updateTag(id: string, data: Partial<TagDto>): Promise<void> {
+  updateTag(id: string, data: Pick<Tag, 'name'>): Promise<void> {
     return this._tagDataService.updateTag(id, data);
   }
 

--- a/libs/menu-matriarch/data-access/src/lib/tag.service.ts
+++ b/libs/menu-matriarch/data-access/src/lib/tag.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { concatMap, first, tap } from 'rxjs/operators';
+import { concatMap, first } from 'rxjs/operators';
 
 import { AuthService } from '@atocha/core/data-access';
 import { Tag } from '@atocha/menu-matriarch/util';
-import { TagDataService } from './internal/tag-data.service';
+import { EditableTagData, TagDataService } from './internal/tag-data.service';
 
 @Injectable({
   providedIn: 'root',
@@ -31,7 +31,7 @@ export class TagService {
     );
   }
 
-  createTag(tag: Pick<Tag, 'name'>): Observable<string | undefined> {
+  createTag(tag: EditableTagData): Observable<string | undefined> {
     return this._authService.uid$.pipe(
       first(),
       concatMap(async (uid) => {
@@ -45,19 +45,11 @@ export class TagService {
     );
   }
 
-  updateTag(id: string, data: Pick<Tag, 'name'>): Promise<void> {
-    return this._tagDataService.updateTag(id, data);
+  async updateTag(tag: Tag, data: EditableTagData): Promise<void> {
+    return this._tagDataService.updateTag(tag, data);
   }
 
-  deleteTag(id: string): Observable<Tag | undefined> {
-    return this.getTag(id).pipe(
-      first(),
-      tap(async (tag) => {
-        if (!tag) {
-          return;
-        }
-        await this._tagDataService.deleteTag(tag);
-      })
-    );
+  async deleteTag(tag: Tag): Promise<void> {
+    return this._tagDataService.deleteTag(tag);
   }
 }

--- a/libs/menu-matriarch/feature-dishes/src/lib/dish-details/dish-details.component.ts
+++ b/libs/menu-matriarch/feature-dishes/src/lib/dish-details/dish-details.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { of } from 'rxjs';
-import { concatMap, first, map, switchMap } from 'rxjs/operators';
+import { concatMap, first, switchMap } from 'rxjs/operators';
 
 import {
   ButtonComponent,
@@ -39,9 +39,6 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DishDetailsComponent {
-  private _id$ = this._route.paramMap.pipe(
-    map((paramMap) => paramMap.get('id'))
-  );
   dish$ = this._route.params.pipe(
     switchMap(({ id }) => {
       if (!id) {
@@ -59,14 +56,14 @@ export class DishDetailsComponent {
   ) {}
 
   onDelete(): void {
-    this._id$
+    this.dish$
       .pipe(
         first(),
-        concatMap((id) => {
-          if (!id) {
+        concatMap((dish) => {
+          if (!dish) {
             return of(undefined);
           }
-          return this._dishService.deleteDish(id);
+          return this._dishService.deleteDish(dish);
         })
       )
       .subscribe(() =>

--- a/libs/menu-matriarch/feature-dishes/src/lib/dish-edit/dish-edit.component.ts
+++ b/libs/menu-matriarch/feature-dishes/src/lib/dish-edit/dish-edit.component.ts
@@ -121,7 +121,7 @@ export class DishEditComponent {
           first(),
           concatMap((dish) => {
             if (dish) {
-              return this._dishService.updateDish(dish.id, details);
+              return this._dishService.updateDish(dish, details);
             } else {
               return of(undefined);
             }

--- a/libs/menu-matriarch/feature-meals/src/lib/meal-details/meal-details.component.ts
+++ b/libs/menu-matriarch/feature-meals/src/lib/meal-details/meal-details.component.ts
@@ -34,9 +34,6 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MealDetailsComponent {
-  private _id$ = this._route.paramMap.pipe(
-    map((paramMap) => paramMap.get('id'))
-  );
   vm$ = combineLatest([
     this._route.params.pipe(
       switchMap(({ id }) => {
@@ -66,14 +63,14 @@ export class MealDetailsComponent {
   ) {}
 
   onDelete(): void {
-    this._id$
+    this.vm$
       .pipe(
         first(),
-        concatMap((id) => {
-          if (!id) {
+        concatMap(({ meal }) => {
+          if (!meal) {
             return of(undefined);
           }
-          return this._mealService.deleteMeal(id);
+          return this._mealService.deleteMeal(meal);
         })
       )
       .subscribe(() =>

--- a/libs/menu-matriarch/feature-meals/src/lib/meal-edit/meal-edit.component.ts
+++ b/libs/menu-matriarch/feature-meals/src/lib/meal-edit/meal-edit.component.ts
@@ -169,7 +169,7 @@ export class MealEditComponent {
           first(),
           concatMap((meal) => {
             if (meal) {
-              return this._mealService.updateMeal(meal.id, details);
+              return this._mealService.updateMeal(meal, details);
             } else {
               return of(undefined);
             }

--- a/libs/menu-matriarch/feature-menus/src/lib/menus.component.html
+++ b/libs/menu-matriarch/feature-menus/src/lib/menus.component.html
@@ -29,7 +29,7 @@
       (print)="onPrint(menu)"
       (rename)="onRename(menu.id, $event)"
       (startDayChange)="onStartDayChange(menu.id, $event)"
-      (delete)="onDelete(menu.id)"
+      (delete)="onDelete(menu)"
     ></li>
   </ul>
 </ui-section>

--- a/libs/menu-matriarch/feature-menus/src/lib/menus.component.ts
+++ b/libs/menu-matriarch/feature-menus/src/lib/menus.component.ts
@@ -66,7 +66,7 @@ export class MenusComponent {
     this._menuService.updateMenuStartDay(id, startDay);
   }
 
-  onDelete(id: string): void {
-    this._menuService.deleteMenu(id);
+  onDelete(menu: Menu): void {
+    this._menuService.deleteMenu(menu);
   }
 }

--- a/libs/menu-matriarch/feature-tags/src/lib/tags.component.html
+++ b/libs/menu-matriarch/feature-tags/src/lib/tags.component.html
@@ -22,8 +22,8 @@
       [name]="tag.name"
       [meals]="tag.mealIds"
       [dishes]="tag.dishIds"
-      (edit)="onTagEdit(tag.id, $event)"
-      (delete)="onTagDelete(tag.id)"
+      (edit)="onTagEdit(tag, $event)"
+      (delete)="onTagDelete(tag)"
     >
       {{ tag.name }}
     </li>

--- a/libs/menu-matriarch/feature-tags/src/lib/tags.component.ts
+++ b/libs/menu-matriarch/feature-tags/src/lib/tags.component.ts
@@ -43,11 +43,11 @@ export class TagsComponent {
     this.finishAdd$.next();
   }
 
-  onTagEdit(id: string, name: string): void {
-    this._tagService.updateTag(id, { name });
+  onTagEdit(tag: Tag, name: string): void {
+    this._tagService.updateTag(tag, { name });
   }
 
-  onTagDelete(id: string): void {
-    this._tagService.deleteTag(id).subscribe();
+  onTagDelete(tag: Tag): void {
+    this._tagService.deleteTag(tag);
   }
 }


### PR DESCRIPTION
1. Simplifies update/delete methods in data services by passing entity objects (rather than the entity ID) all the way through. This saves an additional service call to retrieve the object when it's already available in the component where the request is fired
2. Defines `Editable{{ ENTITY }}Data` type in each service to standardize which properties can be modified when creating/updating an entity