### PR TITLE
Bug fix: fixes ingredients' `dishIds` link in seed data

### DIFF
--- a/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/ingredient-data.ts
+++ b/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/ingredient-data.ts
@@ -18,7 +18,7 @@ export function createIngredientData(
       uid,
       name: 'Garlic',
       typeId: ingredientTypesIds.produce,
-      dishIds: [ingredientTypesIds.refrigerated],
+      dishIds: [dishIds.huevosRotos],
     },
     {
       id: ingredientIds.oliveOil,
@@ -32,7 +32,7 @@ export function createIngredientData(
       uid,
       name: 'Onion',
       typeId: ingredientTypesIds.produce,
-      dishIds: [ingredientTypesIds.refrigerated],
+      dishIds: [dishIds.huevosRotos],
     },
     {
       id: ingredientIds.paprika,
@@ -53,7 +53,7 @@ export function createIngredientData(
       uid,
       name: 'Potato',
       typeId: ingredientTypesIds.produce,
-      dishIds: [ingredientTypesIds.refrigerated],
+      dishIds: [dishIds.huevosRotos],
     },
     {
       id: ingredientIds.salt,

--- a/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/menu-data.ts
+++ b/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/menu-data.ts
@@ -8,7 +8,7 @@ export function createMenuData(
   return [
     {
       id: menuIds.menu,
-      uid: uid,
+      uid,
       name: 'Menu #1',
       contents: {
         Monday: [dishIds.enchiladas],

--- a/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/user-data.ts
+++ b/libs/menu-matriarch/shell/data-access/src/lib/seed-data/data/user-data.ts
@@ -2,7 +2,7 @@ import { UserDto } from '@atocha/menu-matriarch/shared/data-access-dtos';
 import { SeedDataIds } from './seed-data-ids';
 
 export function createUserData({
-  ids,
+  ids: { ingredientTypeIds },
   uid,
   name,
   email,
@@ -13,9 +13,9 @@ export function createUserData({
   email: string;
 }): Partial<UserDto> {
   return {
-    uid: uid,
-    name: name,
-    email: email,
+    uid,
+    name,
+    email,
     preferences: {
       darkMode: false,
       dayNameDisplay: 'full',
@@ -23,9 +23,9 @@ export function createUserData({
       emptyMealText: 'undecided',
       mealOrientation: 'vertical',
       ingredientTypeOrder: [
-        ids.ingredientTypeIds.produce,
-        ids.ingredientTypeIds.refrigerated,
-        ids.ingredientTypeIds.spice,
+        ingredientTypeIds.produce,
+        ingredientTypeIds.refrigerated,
+        ingredientTypeIds.spice,
       ],
     },
   };


### PR DESCRIPTION
1. In https://github.com/johnnycopes/atocha/pull/353, a few of the wrong IDs were linked in the refactoring. This PR fixes them
2. Leverages enhanced object values and nested destructuring for easier reading