### PR TITLE
Autofocus fix

### DIFF
--- a/libs/menu-matriarch/dishes/feature/src/lib/dish-edit/dish-edit-form/dish-edit-form.component.ts
+++ b/libs/menu-matriarch/dishes/feature/src/lib/dish-edit/dish-edit-form/dish-edit-form.component.ts
@@ -12,6 +12,7 @@ import { RouterLink } from '@angular/router';
 import { EditorComponent } from '@tinymce/tinymce-angular';
 
 import {
+  AutofocusDirective,
   ButtonComponent,
   CheckboxComponent,
   trackBySelf,
@@ -42,6 +43,7 @@ export type DishConfig = Pick<
   standalone: true,
   selector: 'app-dish-edit-form',
   imports: [
+    AutofocusDirective,
     ButtonComponent,
     CheckboxComponent,
     CommonModule,


### PR DESCRIPTION
The autofocus behavior on the "Name" input wasn't working in the dish edit form. Though the `coreAutofocus` directive was being applied in the `DishEditComponent`, the directive wasn't being imported