### PR TITLE
Tree libs safety improvements

### DIFF
--- a/libs/tree/ui/src/lib/selection-tree/selection-tree.component.ts
+++ b/libs/tree/ui/src/lib/selection-tree/selection-tree.component.ts
@@ -19,7 +19,7 @@ import {
   FormsModule,
 } from '@angular/forms';
 
-import { States, Transformer } from '@atocha/tree/util';
+import { ArrayModel, States, Transformer } from '@atocha/tree/util';
 import { TreeComponent } from '../tree/tree.component';
 
 @Component({
@@ -49,14 +49,14 @@ export class SelectionTreeComponent<T>
   @Input() getChildren: (node: T) => T[] = () => [];
   @Input() template: TemplateRef<unknown> | undefined;
   @Output() nodeClick = new EventEmitter<string>();
-  model: string[] = [];
+  model: ArrayModel = [];
   states: States = {};
   private _transformer = new Transformer<T>(
     {} as T,
     this.getId,
     this.getChildren
   );
-  private _onChangeFn: (value: string[]) => void = () => [];
+  private _onChangeFn: (value: ArrayModel) => void = () => [];
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
@@ -75,7 +75,7 @@ export class SelectionTreeComponent<T>
     }
   }
 
-  writeValue(model: string[]): void {
+  writeValue(model: ArrayModel): void {
     if (model) {
       this.model = model;
       this.states = this._transformer.updateMultiple(model).states;
@@ -83,12 +83,12 @@ export class SelectionTreeComponent<T>
     this._changeDetectorRef.markForCheck();
   }
 
-  registerOnChange(fn: (value: string[]) => void): void {
+  registerOnChange(fn: (value: ArrayModel) => void): void {
     this._onChangeFn = fn;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-  registerOnTouched(_fn: (value: string[]) => void): void {}
+  registerOnTouched(_fn: (value: ArrayModel) => void): void {}
 
   onChange = (node: T): void => {
     const nodeId = this.getId(node);

--- a/libs/tree/util/src/lib/counter.ts
+++ b/libs/tree/util/src/lib/counter.ts
@@ -1,4 +1,11 @@
-import { GetChildren, GetId, GetLeafCount, Model, Tree } from './shared/types';
+import {
+  GetChildren,
+  GetId,
+  GetLeafCount,
+  Model,
+  Tree,
+  isArrayModel,
+} from './shared/types';
 import { Counts, getCounts } from './counter/get-counts';
 
 export class Counter<T> {
@@ -25,7 +32,7 @@ export class Counter<T> {
   }
 
   update(model: Model): Counter<T> {
-    const set = Array.isArray(model) ? new Set(model) : model;
+    const set = isArrayModel(model) ? new Set(model) : model;
     this._selectedCounts = this._getCounts((leaf: T): number =>
       set.has(this._getId(leaf)) ? this._getLeafCount(leaf) : 0
     );

--- a/libs/tree/util/src/lib/counter.ts
+++ b/libs/tree/util/src/lib/counter.ts
@@ -13,11 +13,11 @@ export class Counter<T> {
   private _selectedCounts: Counts = {};
 
   get totalCounts(): Counts {
-    return { ...this._totalCounts };
+    return this._totalCounts;
   }
 
   get selectedCounts(): Counts {
-    return { ...this._selectedCounts };
+    return this._selectedCounts;
   }
 
   constructor(

--- a/libs/tree/util/src/lib/counter/get-counts.ts
+++ b/libs/tree/util/src/lib/counter/get-counts.ts
@@ -1,11 +1,11 @@
 import { reduceRecursively } from '../shared/reduce-recursively';
-import { GetChildren, GetId, GetLeafCount } from '../shared/types';
+import { GetChildren, GetId, GetLeafCount, Tree } from '../shared/types';
 
 export type Counts = Readonly<MutableCounts>;
 type MutableCounts = Record<string, number>;
 
 export function getCounts<T>(
-  tree: T,
+  tree: Tree<T>,
   getId: GetId<T>,
   getChildren: GetChildren<T>,
   getLeafCount: GetLeafCount<T>

--- a/libs/tree/util/src/lib/counter/get-counts.ts
+++ b/libs/tree/util/src/lib/counter/get-counts.ts
@@ -1,15 +1,16 @@
 import { reduceRecursively } from '../shared/reduce-recursively';
 import { GetChildren, GetId, GetLeafCount } from '../shared/types';
 
-export type Counts = Record<string, number>;
+export type Counts = Readonly<MutableCounts>;
+type MutableCounts = Record<string, number>;
 
 export function getCounts<T>(
   tree: T,
   getId: GetId<T>,
   getChildren: GetChildren<T>,
   getLeafCount: GetLeafCount<T>
-) {
-  return reduceRecursively<T, Counts>({
+): Counts {
+  return reduceRecursively<T, MutableCounts>({
     item: tree,
     getItems: getChildren,
     initialValue: {},

--- a/libs/tree/util/src/lib/shared/reduce-recursively.ts
+++ b/libs/tree/util/src/lib/shared/reduce-recursively.ts
@@ -9,7 +9,7 @@ export function reduceRecursively<T, U>({
   item: Tree<T>;
   getItems: GetChildren<T>;
   initialValue: U;
-  reducer: (accumulator: U, item: T, parent?: T) => U;
+  reducer: (accumulator: U, item: Tree<T>, parent?: T) => U;
 }): U {
   const items = [item];
   let value = reducer(initialValue, item);

--- a/libs/tree/util/src/lib/shared/types.ts
+++ b/libs/tree/util/src/lib/shared/types.ts
@@ -9,7 +9,7 @@ export type MutableStates = Record<string, State>;
 export type States = Readonly<MutableStates>;
 export type State = 'checked' | 'indeterminate';
 
-export type Tree<T> = T;
+export type Tree<T> = Readonly<T>;
 export type GetId<T> = (item: T) => string;
 export type GetChildren<T> = (item: T) => readonly T[];
 export type GetLeafCount<T> = (item: T) => number;

--- a/libs/tree/util/src/lib/shared/types.ts
+++ b/libs/tree/util/src/lib/shared/types.ts
@@ -1,6 +1,6 @@
 export type Model = ArrayModel | SetModel;
 export type ArrayModel = string[];
-export type SetModel = Set<string>;
+export type SetModel = ReadonlySet<string>;
 
 export type States = Record<string, State>;
 export type State = 'checked' | 'indeterminate';

--- a/libs/tree/util/src/lib/shared/types.ts
+++ b/libs/tree/util/src/lib/shared/types.ts
@@ -1,6 +1,9 @@
-export type Model = string[] | Set<string>;
-export type State = 'checked' | 'indeterminate';
+export type Model = ArrayModel | SetModel;
+export type ArrayModel = string[];
+export type SetModel = Set<string>;
+
 export type States = Record<string, State>;
+export type State = 'checked' | 'indeterminate';
 
 export type Tree<T> = T;
 export type GetId<T> = (item: T) => string;

--- a/libs/tree/util/src/lib/shared/types.ts
+++ b/libs/tree/util/src/lib/shared/types.ts
@@ -5,7 +5,8 @@ export function isArrayModel(model: Model): model is ArrayModel {
   return Array.isArray(model);
 }
 
-export type States = Record<string, State>;
+export type MutableStates = Record<string, State>;
+export type States = Readonly<MutableStates>;
 export type State = 'checked' | 'indeterminate';
 
 export type Tree<T> = T;

--- a/libs/tree/util/src/lib/shared/types.ts
+++ b/libs/tree/util/src/lib/shared/types.ts
@@ -1,6 +1,9 @@
 export type Model = ArrayModel | SetModel;
-export type ArrayModel = string[];
+export type ArrayModel = readonly string[];
 export type SetModel = ReadonlySet<string>;
+export function isArrayModel(model: Model): model is ArrayModel {
+  return Array.isArray(model);
+}
 
 export type States = Record<string, State>;
 export type State = 'checked' | 'indeterminate';

--- a/libs/tree/util/src/lib/transformer.ts
+++ b/libs/tree/util/src/lib/transformer.ts
@@ -4,8 +4,9 @@ import {
   GetId,
   Model,
   SetModel,
-  States,
+  MutableStates,
   Tree,
+  States,
 } from './shared/types';
 import { Ids } from './transformer/ids/ids';
 import { toArray } from './transformer/to-array';
@@ -15,18 +16,18 @@ import { updateStates } from './transformer/update-states';
 
 export class Transformer<T> {
   private readonly _ids: Ids<T>;
-  private _states: States;
+  private _states: MutableStates;
 
-  get states(): Readonly<States> {
+  get states(): States {
     return this._states;
   }
 
   get array(): ArrayModel {
-    return toArray(this._states, this._ids);
+    return toArray(this.states, this._ids);
   }
 
   get set(): SetModel {
-    return toSet(this._states, this._ids);
+    return toSet(this.states, this._ids);
   }
 
   constructor(
@@ -53,7 +54,7 @@ export class Transformer<T> {
     return this;
   }
 
-  private _toStates(model: Model): States {
+  private _toStates(model: Model): MutableStates {
     return toStates(model, this._ids);
   }
 }

--- a/libs/tree/util/src/lib/transformer.ts
+++ b/libs/tree/util/src/lib/transformer.ts
@@ -9,8 +9,8 @@ export class Transformer<T> {
   private readonly _ids: Ids<T>;
   private _states: States;
 
-  get states(): States {
-    return { ...this._states };
+  get states(): Readonly<States> {
+    return this._states;
   }
 
   get array(): Extract<Model, string[]> {

--- a/libs/tree/util/src/lib/transformer.ts
+++ b/libs/tree/util/src/lib/transformer.ts
@@ -1,4 +1,12 @@
-import { GetChildren, GetId, Model, States, Tree } from './shared/types';
+import {
+  ArrayModel,
+  GetChildren,
+  GetId,
+  Model,
+  SetModel,
+  States,
+  Tree,
+} from './shared/types';
 import { Ids } from './transformer/ids/ids';
 import { toArray } from './transformer/to-array';
 import { toSet } from './transformer/to-set';
@@ -13,11 +21,11 @@ export class Transformer<T> {
     return this._states;
   }
 
-  get array(): Extract<Model, string[]> {
+  get array(): ArrayModel {
     return toArray(this._states, this._ids);
   }
 
-  get set(): Extract<Model, Set<string>> {
+  get set(): SetModel {
     return toSet(this._states, this._ids);
   }
 

--- a/libs/tree/util/src/lib/transformer/ids/ids.ts
+++ b/libs/tree/util/src/lib/transformer/ids/ids.ts
@@ -27,7 +27,7 @@ export class Ids<T> {
   }> {
     const itemAndDescendantsIds = reduceRecursively<string, string[]>({
       item: id,
-      getItems: (id: string) => this._map.get(id)?.childrenIds ?? [], // TODO: call getChildrenIds
+      getItems: (id) => this.getChildrenIds(id),
       initialValue: [],
       reducer: (accum, curr) => {
         accum.push(curr);

--- a/libs/tree/util/src/lib/transformer/ids/ids.ts
+++ b/libs/tree/util/src/lib/transformer/ids/ids.ts
@@ -21,10 +21,10 @@ export class Ids<T> {
     return this._map.get(id)?.childrenIds ?? [];
   }
 
-  getConnectedIds(id: string): {
-    itemAndDescendantsIds: string[];
-    ancestorIds: string[];
-  } {
+  getConnectedIds(id: string): Readonly<{
+    itemAndDescendantsIds: readonly string[];
+    ancestorIds: readonly string[];
+  }> {
     const itemAndDescendantsIds = reduceRecursively<string, string[]>({
       item: id,
       getItems: (id: string) => this._map.get(id)?.childrenIds ?? [], // TODO: call getChildrenIds

--- a/libs/tree/util/src/lib/transformer/to-array.ts
+++ b/libs/tree/util/src/lib/transformer/to-array.ts
@@ -1,10 +1,7 @@
-import { Model, States } from '../shared/types';
+import { ArrayModel, States } from '../shared/types';
 import { Ids } from './ids/ids';
 
-export function toArray<T>(
-  states: States,
-  ids: Ids<T>
-): Extract<Model, string[]> {
+export function toArray<T>(states: States, ids: Ids<T>): ArrayModel {
   const model: string[] = [];
 
   for (const id of ids.descending) {

--- a/libs/tree/util/src/lib/transformer/to-set.ts
+++ b/libs/tree/util/src/lib/transformer/to-set.ts
@@ -1,10 +1,7 @@
-import { Model, States } from '../shared/types';
+import { SetModel, States } from '../shared/types';
 import { Ids } from './ids/ids';
 import { toArray } from './to-array';
 
-export function toSet<T>(
-  states: States,
-  ids: Ids<T>
-): Extract<Model, Set<string>> {
+export function toSet<T>(states: States, ids: Ids<T>): SetModel {
   return new Set(toArray(states, ids));
 }

--- a/libs/tree/util/src/lib/transformer/to-states.ts
+++ b/libs/tree/util/src/lib/transformer/to-states.ts
@@ -1,9 +1,9 @@
-import { Model, States } from '../shared/types';
+import { Model, States, isArrayModel } from '../shared/types';
 import { Ids } from './ids/ids';
 
 export function toStates<T>(model: Model, ids: Ids<T>): States {
   const states: States = {};
-  const idsModel = Array.isArray(model) ? new Set(model) : model;
+  const idsModel = isArrayModel(model) ? new Set(model) : model;
 
   /*
     Iterating through the IDs backwards builds up `states` from the leaf nodes

--- a/libs/tree/util/src/lib/transformer/to-states.ts
+++ b/libs/tree/util/src/lib/transformer/to-states.ts
@@ -1,8 +1,8 @@
-import { Model, States, isArrayModel } from '../shared/types';
+import { Model, MutableStates, isArrayModel } from '../shared/types';
 import { Ids } from './ids/ids';
 
-export function toStates<T>(model: Model, ids: Ids<T>): States {
-  const states: States = {};
+export function toStates<T>(model: Model, ids: Ids<T>): MutableStates {
+  const states: MutableStates = {};
   const idsModel = isArrayModel(model) ? new Set(model) : model;
 
   /*

--- a/libs/tree/util/src/lib/transformer/update-states.ts
+++ b/libs/tree/util/src/lib/transformer/update-states.ts
@@ -1,4 +1,4 @@
-import { State, States } from '../shared/types';
+import { State, MutableStates } from '../shared/types';
 import { Ids } from './ids/ids';
 
 export function updateStates<T>({
@@ -6,7 +6,7 @@ export function updateStates<T>({
   ids,
   targetId,
 }: {
-  states: States;
+  states: MutableStates;
   ids: Ids<T>;
   targetId: string;
 }): void {

--- a/libs/tree/util/src/lib/types.ts
+++ b/libs/tree/util/src/lib/types.ts
@@ -1,5 +1,7 @@
 import {
   Model as InternalModel,
+  ArrayModel as InternalArrayModel,
+  SetModel as InternalSetModel,
   State as InternalState,
   States as InternalStates,
   Tree as InternalTree,
@@ -10,6 +12,9 @@ import {
 import { Counts as InternalCounts } from './counter/get-counts';
 
 export type Model = InternalModel;
+export type ArrayModel = InternalArrayModel;
+export type SetModel = InternalSetModel;
+
 export type State = InternalState;
 export type States = InternalStates;
 export type Counts = InternalCounts;


### PR DESCRIPTION
1. Defines concrete `ArrayModel` and `SetModel` within `Model` for simpler typing
2. Makes `ArrayModel`, `SetModel`, `States`, and `Counts` readonly values (all exposed values from public API are now `readonly`)
3. Internally introduces and manages `MutableStates` and `MutableCounts` 
4. Improves type safety of values returned from `getConnectedIds`
5. Makes `Tree` type readonly and implements it where sensible