### PR TITLE
Updates `tsconfig` files across project

### DIFF
--- a/apps/globetrotter/tsconfig.json
+++ b/apps/globetrotter/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/apps/lorenzo/tsconfig.json
+++ b/apps/lorenzo/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/apps/menu-matriarch/tsconfig.json
+++ b/apps/menu-matriarch/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/apps/spirit-islander/tsconfig.json
+++ b/apps/spirit-islander/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/core/data-access/tsconfig.json
+++ b/libs/core/data-access/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/core/ui/tsconfig.json
+++ b/libs/core/ui/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/globetrotter/data-access/tsconfig.json
+++ b/libs/globetrotter/data-access/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/globetrotter/feature-explore/tsconfig.json
+++ b/libs/globetrotter/feature-explore/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/globetrotter/feature-learn/tsconfig.json
+++ b/libs/globetrotter/feature-learn/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/globetrotter/feature-shell/tsconfig.json
+++ b/libs/globetrotter/feature-shell/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/globetrotter/ui/tsconfig.json
+++ b/libs/globetrotter/ui/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/lorenzo/data-access/tsconfig.json
+++ b/libs/lorenzo/data-access/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/lorenzo/feature-browse/tsconfig.json
+++ b/libs/lorenzo/feature-browse/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/lorenzo/ui/tsconfig.json
+++ b/libs/lorenzo/ui/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/dishes/data-access/tsconfig.json
+++ b/libs/menu-matriarch/dishes/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/dishes/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/dishes/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/dishes/feature/tsconfig.json
+++ b/libs/menu-matriarch/dishes/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/ingredients/data-access/tsconfig.json
+++ b/libs/menu-matriarch/ingredients/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/ingredients/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/ingredients/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/ingredients/feature/tsconfig.json
+++ b/libs/menu-matriarch/ingredients/feature/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/meals/data-access/tsconfig.json
+++ b/libs/menu-matriarch/meals/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/meals/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/meals/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/meals/feature/tsconfig.json
+++ b/libs/menu-matriarch/meals/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/menus/data-access/tsconfig.json
+++ b/libs/menu-matriarch/menus/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/menus/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/menus/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/menus/feature/tsconfig.json
+++ b/libs/menu-matriarch/menus/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/planner/data-access/tsconfig.json
+++ b/libs/menu-matriarch/planner/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/planner/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/planner/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/planner/feature/tsconfig.json
+++ b/libs/menu-matriarch/planner/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/settings/data-access/tsconfig.json
+++ b/libs/menu-matriarch/settings/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/settings/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/settings/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/settings/feature/tsconfig.json
+++ b/libs/menu-matriarch/settings/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/data-access-api/tsconfig.json
+++ b/libs/menu-matriarch/shared/data-access-api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/data-access-api/tsconfig.spec.json
+++ b/libs/menu-matriarch/shared/data-access-api/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/shared/data-access-dtos/tsconfig.json
+++ b/libs/menu-matriarch/shared/data-access-dtos/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/data-access-dtos/tsconfig.spec.json
+++ b/libs/menu-matriarch/shared/data-access-dtos/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/shared/data-access-routing/tsconfig.json
+++ b/libs/menu-matriarch/shared/data-access-routing/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/data-access-routing/tsconfig.spec.json
+++ b/libs/menu-matriarch/shared/data-access-routing/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/shared/feature/tsconfig.json
+++ b/libs/menu-matriarch/shared/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/ui-domain/tsconfig.json
+++ b/libs/menu-matriarch/shared/ui-domain/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shared/ui-generic/tsconfig.json
+++ b/libs/menu-matriarch/shared/ui-generic/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shell/data-access/tsconfig.json
+++ b/libs/menu-matriarch/shell/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/shell/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/shell/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/shell/feature/tsconfig.json
+++ b/libs/menu-matriarch/shell/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/tags/data-access/tsconfig.json
+++ b/libs/menu-matriarch/tags/data-access/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/menu-matriarch/tags/data-access/tsconfig.spec.json
+++ b/libs/menu-matriarch/tags/data-access/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/menu-matriarch/tags/feature/tsconfig.json
+++ b/libs/menu-matriarch/tags/feature/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/spirit-islander/data-access/tsconfig.json
+++ b/libs/spirit-islander/data-access/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/spirit-islander/feature-config/tsconfig.json
+++ b/libs/spirit-islander/feature-config/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/spirit-islander/feature-game-setup/tsconfig.json
+++ b/libs/spirit-islander/feature-game-setup/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/spirit-islander/feature-shell/tsconfig.json
+++ b/libs/spirit-islander/feature-shell/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/spirit-islander/ui/tsconfig.json
+++ b/libs/spirit-islander/ui/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/tree/ui/tsconfig.json
+++ b/libs/tree/ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/tree/ui/tsconfig.spec.json
+++ b/libs/tree/ui/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2020",
+    "target": "es2022",
     "module": "esnext",
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es2022",
+    "useDefineForClassFields": false,
     "module": "esnext",
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,


### PR DESCRIPTION
1. Sets `"target"` to `"es2022"` in all tsconfig files
2. Sets `"useDefineForClassFields"` to `false` in tsconfig.base in order to silence warning

Warning text:
```
TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and "false" respectively by the Angular CLI. To control ECMA version and features use the Browerslist configuration. For more information, see https://angular.io/guide/build#configuring-browser-compatibility
    NOTE: You can set the "target" to "ES2022" in the project's tsconfig to remove this warning.
```