### PR TITLE
Enforce more consistency in MM data services

### DIFF
--- a/libs/firebase/data-access/src/lib/data.service.ts
+++ b/libs/firebase/data-access/src/lib/data.service.ts
@@ -3,42 +3,33 @@ import { Observable } from 'rxjs';
 
 import { FirestoreService } from './firestore/firestore.service';
 
-interface IDataService<T> {
-  createId(): string;
-  getOne(endpoint: string, id: string): Observable<T | undefined>;
-  getMany(endpoint: string, uid: string): Observable<T[]>;
-  create(endpoint: string, id: string, details: T): Promise<void>;
-  update(endpoint: string, id: string, data: Partial<T>): Promise<void>;
-  delete(endpoint: string, id: string): Promise<void>;
-}
-
 @Injectable({
   providedIn: 'root',
 })
-export class DataService<T> implements IDataService<T> {
+export class DataService<T> {
   constructor(private _firestoreService: FirestoreService) {}
 
-  createId() {
+  createId(): string {
     return this._firestoreService.createId();
   }
 
-  getOne(endpoint: string, id: string) {
+  getOne(endpoint: string, id: string): Observable<T | undefined> {
     return this._firestoreService.getOne<T>(endpoint, id);
   }
 
-  getMany(endpoint: string, uid: string) {
+  getMany(endpoint: string, uid: string): Observable<T[]> {
     return this._firestoreService.getMany<T>(endpoint, uid);
   }
 
-  async create(endpoint: string, id: string, details: T) {
+  async create(endpoint: string, id: string, details: T): Promise<void> {
     return this._firestoreService.create<T>(endpoint, id, details);
   }
 
-  async update(endpoint: string, id: string, data: Partial<T>) {
+  async update(endpoint: string, id: string, data: Partial<T>): Promise<void> {
     return await this._firestoreService.update<T>(endpoint, id, data);
   }
 
-  async delete(endpoint: string, id: string) {
+  async delete(endpoint: string, id: string): Promise<void> {
     return await this._firestoreService.delete<T>(endpoint, id);
   }
 }

--- a/libs/firebase/data-access/src/lib/data.service.ts
+++ b/libs/firebase/data-access/src/lib/data.service.ts
@@ -3,37 +3,42 @@ import { Observable } from 'rxjs';
 
 import { FirestoreService } from './firestore/firestore.service';
 
+interface IDataService<T> {
+  createId(): string;
+  getOne(endpoint: string, id: string): Observable<T | undefined>;
+  getMany(endpoint: string, uid: string): Observable<T[]>;
+  create(endpoint: string, id: string, details: T): Promise<void>;
+  update(endpoint: string, id: string, data: Partial<T>): Promise<void>;
+  delete(endpoint: string, id: string): Promise<void>;
+}
+
 @Injectable({
   providedIn: 'root',
 })
-export class DataService {
+export class DataService<T> implements IDataService<T> {
   constructor(private _firestoreService: FirestoreService) {}
 
   createId(): string {
     return this._firestoreService.createId();
   }
 
-  getOne<T>(endpoint: string, id: string): Observable<T | undefined> {
+  getOne(endpoint: string, id: string): Observable<T | undefined> {
     return this._firestoreService.getOne(endpoint, id);
   }
 
-  getMany<T>(endpoint: string, uid: string): Observable<T[]> {
+  getMany(endpoint: string, uid: string): Observable<T[]> {
     return this._firestoreService.getMany(endpoint, uid);
   }
 
-  async create<T>(endpoint: string, id: string, details: T): Promise<void> {
+  async create(endpoint: string, id: string, details: T): Promise<void> {
     return this._firestoreService.create(endpoint, id, details);
   }
 
-  async update<T>(
-    endpoint: string,
-    id: string,
-    data: Partial<T>
-  ): Promise<void> {
+  async update(endpoint: string, id: string, data: Partial<T>): Promise<void> {
     return await this._firestoreService.update(endpoint, id, data);
   }
 
-  async delete<T>(endpoint: string, id: string): Promise<void> {
+  async delete(endpoint: string, id: string): Promise<void> {
     return await this._firestoreService.delete<T>(endpoint, id);
   }
 }

--- a/libs/firebase/data-access/src/lib/data.service.ts
+++ b/libs/firebase/data-access/src/lib/data.service.ts
@@ -18,27 +18,27 @@ interface IDataService<T> {
 export class DataService<T> implements IDataService<T> {
   constructor(private _firestoreService: FirestoreService) {}
 
-  createId(): string {
+  createId() {
     return this._firestoreService.createId();
   }
 
-  getOne(endpoint: string, id: string): Observable<T | undefined> {
-    return this._firestoreService.getOne(endpoint, id);
+  getOne(endpoint: string, id: string) {
+    return this._firestoreService.getOne<T>(endpoint, id);
   }
 
-  getMany(endpoint: string, uid: string): Observable<T[]> {
-    return this._firestoreService.getMany(endpoint, uid);
+  getMany(endpoint: string, uid: string) {
+    return this._firestoreService.getMany<T>(endpoint, uid);
   }
 
-  async create(endpoint: string, id: string, details: T): Promise<void> {
-    return this._firestoreService.create(endpoint, id, details);
+  async create(endpoint: string, id: string, details: T) {
+    return this._firestoreService.create<T>(endpoint, id, details);
   }
 
-  async update(endpoint: string, id: string, data: Partial<T>): Promise<void> {
-    return await this._firestoreService.update(endpoint, id, data);
+  async update(endpoint: string, id: string, data: Partial<T>) {
+    return await this._firestoreService.update<T>(endpoint, id, data);
   }
 
-  async delete(endpoint: string, id: string): Promise<void> {
+  async delete(endpoint: string, id: string) {
     return await this._firestoreService.delete<T>(endpoint, id);
   }
 }

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -41,15 +42,15 @@ export class DishDataService implements DtoService<Dish, DishDto> {
     private _tagUpdateService: TagUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<DishDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<DishDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, dish: EditableDishData) {
+  async create(uid: string, dish: EditableDishData): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -84,7 +85,7 @@ export class DishDataService implements DtoService<Dish, DishDto> {
     return id;
   }
 
-  async update(dish: Dish, data: EditableDishData) {
+  async update(dish: Dish, data: EditableDishData): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -117,7 +118,7 @@ export class DishDataService implements DtoService<Dish, DishDto> {
     await batch.commit();
   }
 
-  async delete(dish: Dish) {
+  async delete(dish: Dish): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, dish.id).updateMultiple([

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -11,6 +10,7 @@ import {
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
   DishDto,
+  DtoService,
   createDishDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
 import { Dish } from '@atocha/menu-matriarch/shared/util';
@@ -29,7 +29,7 @@ export type EditableDishData = Pick<
 @Injectable({
   providedIn: 'root',
 })
-export class DishDataService {
+export class DishDataService implements DtoService<Dish, DishDto> {
   private _endpoint = Endpoint.dishes;
 
   constructor(
@@ -41,15 +41,15 @@ export class DishDataService {
     private _tagUpdateService: TagUpdateService
   ) {}
 
-  getDish(id: string): Observable<DishDto | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getDishes(uid: string): Observable<DishDto[]> {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createDish(uid: string, dish: EditableDishData): Promise<string> {
+  async create(uid: string, dish: EditableDishData) {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -84,7 +84,7 @@ export class DishDataService {
     return id;
   }
 
-  async updateDish(dish: Dish, data: EditableDishData): Promise<void> {
+  async update(dish: Dish, data: EditableDishData) {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -117,7 +117,7 @@ export class DishDataService {
     await batch.commit();
   }
 
-  async deleteDish(dish: Dish): Promise<void> {
+  async delete(dish: Dish) {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, dish.id).updateMultiple([

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
@@ -34,7 +34,7 @@ export class DishDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<DishDto>,
     private _mealUpdateService: MealUpdateService,
     private _menuUpdateService: MenuUpdateService,
     private _ingredientUpdateService: IngredientUpdateService,
@@ -42,11 +42,11 @@ export class DishDataService {
   ) {}
 
   getDish(id: string): Observable<DishDto | undefined> {
-    return this._dataService.getOne<DishDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getDishes(uid: string): Observable<DishDto[]> {
-    return this._dataService.getMany<DishDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createDish(uid: string, dish: EditableDishData): Promise<string> {

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish-data.service.ts
@@ -31,7 +31,7 @@ export type EditableDishData = Pick<
   providedIn: 'root',
 })
 export class DishDataService implements DtoService<Dish, DishDto> {
-  private _endpoint = Endpoint.dishes;
+  private readonly _endpoint = Endpoint.dishes;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
@@ -28,7 +28,7 @@ export class DishService {
 
   getDish(id: string): Observable<Dish | undefined> {
     return combineLatest([
-      this._dishDataService.getDish(id),
+      this._dishDataService.getOne(id),
       this._ingredientService.getIngredients(),
       this._tagService.getTags(),
     ]).pipe(
@@ -47,7 +47,7 @@ export class DishService {
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._dishDataService.getDishes(uid),
+            this._dishDataService.getMany(uid),
             this._ingredientService.getIngredients(),
             this._tagService.getTags(),
           ]).pipe(
@@ -68,7 +68,7 @@ export class DishService {
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._dishDataService.createDish(uid, dish);
+          const id = await this._dishDataService.create(uid, dish);
           return id;
         } else {
           return undefined;
@@ -78,10 +78,10 @@ export class DishService {
   }
 
   async updateDish(dish: Dish, data: EditableDishData): Promise<void> {
-    return this._dishDataService.updateDish(dish, data);
+    return this._dishDataService.update(dish, data);
   }
 
   async deleteDish(dish: Dish): Promise<void> {
-    return this._dishDataService.deleteDish(dish);
+    return this._dishDataService.delete(dish);
   }
 }

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -21,7 +21,9 @@ export type EditableIngredientData = Pick<
 @Injectable({
   providedIn: 'root',
 })
-export class IngredientDataService implements DtoService<IngredientDto> {
+export class IngredientDataService
+  implements DtoService<Ingredient, IngredientDto>
+{
   private _endpoint = Endpoint.ingredients;
 
   constructor(

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -25,7 +25,7 @@ export type EditableIngredientData = Pick<
 export class IngredientDataService
   implements DtoService<Ingredient, IngredientDto>
 {
-  private _endpoint = Endpoint.ingredients;
+  private readonly _endpoint = Endpoint.ingredients;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -8,6 +7,7 @@ import {
   IngredientTypeUpdateService,
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
+  DtoService,
   IngredientDto,
   createIngredientDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
@@ -21,7 +21,7 @@ export type EditableIngredientData = Pick<
 @Injectable({
   providedIn: 'root',
 })
-export class IngredientDataService {
+export class IngredientDataService implements DtoService<IngredientDto> {
   private _endpoint = Endpoint.ingredients;
 
   constructor(
@@ -31,18 +31,15 @@ export class IngredientDataService {
     private _ingredientTypeUpdateService: IngredientTypeUpdateService
   ) {}
 
-  getIngredient(id: string): Observable<IngredientDto | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getIngredients(uid: string): Observable<IngredientDto[]> {
+  getMultiple(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createIngredient(
-    uid: string,
-    ingredient: EditableIngredientData
-  ): Promise<string> {
+  async create(uid: string, ingredient: EditableIngredientData) {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -63,10 +60,7 @@ export class IngredientDataService {
     return id;
   }
 
-  async updateIngredient(
-    ingredient: Ingredient,
-    updates: EditableIngredientData
-  ): Promise<void> {
+  async update(ingredient: Ingredient, updates: EditableIngredientData) {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -88,7 +82,7 @@ export class IngredientDataService {
     await batch.commit();
   }
 
-  async deleteIngredient(ingredient: Ingredient): Promise<void> {
+  async delete(ingredient: Ingredient) {
     const batch = this._batchService.createBatch();
 
     batch.delete(Endpoint.ingredients, ingredient.id).updateMultiple([

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -35,7 +35,7 @@ export class IngredientDataService implements DtoService<IngredientDto> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMultiple(uid: string) {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -33,15 +34,18 @@ export class IngredientDataService
     private _ingredientTypeUpdateService: IngredientTypeUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<IngredientDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<IngredientDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, ingredient: EditableIngredientData) {
+  async create(
+    uid: string,
+    ingredient: EditableIngredientData
+  ): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -62,7 +66,10 @@ export class IngredientDataService
     return id;
   }
 
-  async update(ingredient: Ingredient, updates: EditableIngredientData) {
+  async update(
+    ingredient: Ingredient,
+    updates: EditableIngredientData
+  ): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -84,7 +91,7 @@ export class IngredientDataService
     await batch.commit();
   }
 
-  async delete(ingredient: Ingredient) {
+  async delete(ingredient: Ingredient): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(Endpoint.ingredients, ingredient.id).updateMultiple([

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-data.service.ts
@@ -26,17 +26,17 @@ export class IngredientDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<IngredientDto>,
     private _dishUpdateService: DishUpdateService,
     private _ingredientTypeUpdateService: IngredientTypeUpdateService
   ) {}
 
   getIngredient(id: string): Observable<IngredientDto | undefined> {
-    return this._dataService.getOne<IngredientDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getIngredients(uid: string): Observable<IngredientDto[]> {
-    return this._dataService.getMany<IngredientDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createIngredient(

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -30,15 +31,18 @@ export class IngredientTypeDataService
     private _userUpdateService: UserUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<IngredientTypeDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<IngredientTypeDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, ingredientType: EditableIngredientTypeData) {
+  async create(
+    uid: string,
+    ingredientType: EditableIngredientTypeData
+  ): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -62,11 +66,11 @@ export class IngredientTypeDataService
   async update(
     ingredientType: IngredientType,
     updates: EditableIngredientTypeData
-  ) {
+  ): Promise<void> {
     return this._dataService.update(this._endpoint, ingredientType.id, updates);
   }
 
-  async delete(ingredientType: IngredientType) {
+  async delete(ingredientType: IngredientType): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, ingredientType.id).update(

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
@@ -24,16 +24,16 @@ export class IngredientTypeDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<IngredientTypeDto>,
     private _userUpdateService: UserUpdateService
   ) {}
 
   getIngredientType(id: string): Observable<IngredientTypeDto | undefined> {
-    return this._dataService.getOne<IngredientTypeDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getIngredientTypes(uid: string): Observable<IngredientTypeDto[]> {
-    return this._dataService.getMany<IngredientTypeDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createIngredientType(
@@ -64,11 +64,7 @@ export class IngredientTypeDataService {
     ingredientType: IngredientType,
     updates: EditableIngredientTypeData
   ): Promise<void> {
-    return this._dataService.update<IngredientTypeDto>(
-      this._endpoint,
-      ingredientType.id,
-      updates
-    );
+    return this._dataService.update(this._endpoint, ingredientType.id, updates);
   }
 
   async deleteIngredientType(ingredientType: IngredientType): Promise<void> {

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
@@ -23,7 +23,7 @@ export type EditableIngredientTypeData = Partial<
 export class IngredientTypeDataService
   implements DtoService<IngredientType, IngredientTypeDto>
 {
-  private _endpoint = Endpoint.ingredientTypes;
+  private readonly _endpoint = Endpoint.ingredientTypes;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -7,6 +6,7 @@ import {
   UserUpdateService,
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
+  DtoService,
   IngredientTypeDto,
   createIngredientTypeDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
@@ -19,7 +19,9 @@ export type EditableIngredientTypeData = Partial<
 @Injectable({
   providedIn: 'root',
 })
-export class IngredientTypeDataService {
+export class IngredientTypeDataService
+  implements DtoService<IngredientType, IngredientTypeDto>
+{
   private _endpoint = Endpoint.ingredientTypes;
 
   constructor(
@@ -28,18 +30,15 @@ export class IngredientTypeDataService {
     private _userUpdateService: UserUpdateService
   ) {}
 
-  getIngredientType(id: string): Observable<IngredientTypeDto | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getIngredientTypes(uid: string): Observable<IngredientTypeDto[]> {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createIngredientType(
-    uid: string,
-    ingredientType: EditableIngredientTypeData
-  ): Promise<string> {
+  async create(uid: string, ingredientType: EditableIngredientTypeData) {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -60,14 +59,14 @@ export class IngredientTypeDataService {
     return id;
   }
 
-  async updateIngredientType(
+  async update(
     ingredientType: IngredientType,
     updates: EditableIngredientTypeData
-  ): Promise<void> {
+  ) {
     return this._dataService.update(this._endpoint, ingredientType.id, updates);
   }
 
-  async deleteIngredientType(ingredientType: IngredientType): Promise<void> {
+  async delete(ingredientType: IngredientType) {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, ingredientType.id).update(

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type.service.ts
@@ -23,7 +23,7 @@ export class IngredientTypeService {
 
   getIngredientType(id: string): Observable<IngredientType | undefined> {
     return combineLatest([
-      this._ingredientTypeDataService.getIngredientType(id),
+      this._ingredientTypeDataService.getOne(id),
       this._ingredientService.getIngredients(),
     ]).pipe(
       map(([ingredientTypeDto, ingredients]) => {
@@ -44,7 +44,7 @@ export class IngredientTypeService {
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._ingredientTypeDataService.getIngredientTypes(uid),
+            this._ingredientTypeDataService.getMany(uid),
             this._ingredientService.getIngredients(),
           ]).pipe(
             map(([dishDtos, ingredients]) =>
@@ -66,7 +66,7 @@ export class IngredientTypeService {
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._ingredientTypeDataService.createIngredientType(
+          const id = await this._ingredientTypeDataService.create(
             uid,
             ingredientType
           );
@@ -82,13 +82,10 @@ export class IngredientTypeService {
     ingredientType: IngredientType,
     updates: EditableIngredientTypeData
   ): Promise<void> {
-    return this._ingredientTypeDataService.updateIngredientType(
-      ingredientType,
-      updates
-    );
+    return this._ingredientTypeDataService.update(ingredientType, updates);
   }
 
   async deleteIngredientType(ingredientType: IngredientType): Promise<void> {
-    return this._ingredientTypeDataService.deleteIngredientType(ingredientType);
+    return this._ingredientTypeDataService.delete(ingredientType);
   }
 }

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
@@ -19,7 +19,7 @@ export class IngredientService {
   ) {}
 
   getIngredient(id: string): Observable<Ingredient | undefined> {
-    return this._ingredientDataService.getIngredient(id);
+    return this._ingredientDataService.getOne(id);
   }
 
   getIngredients(): Observable<Ingredient[]> {
@@ -27,7 +27,7 @@ export class IngredientService {
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._ingredientDataService.getIngredients(uid);
+          return this._ingredientDataService.getMultiple(uid);
         }
         return of([]);
       })
@@ -41,10 +41,7 @@ export class IngredientService {
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._ingredientDataService.createIngredient(
-            uid,
-            ingredient
-          );
+          const id = await this._ingredientDataService.create(uid, ingredient);
           return id;
         } else {
           return undefined;
@@ -57,10 +54,10 @@ export class IngredientService {
     ingredient: Ingredient,
     updates: EditableIngredientData
   ): Promise<void> {
-    return this._ingredientDataService.updateIngredient(ingredient, updates);
+    return this._ingredientDataService.update(ingredient, updates);
   }
 
   deleteIngredient(ingredient: Ingredient): Promise<void> {
-    return this._ingredientDataService.deleteIngredient(ingredient);
+    return this._ingredientDataService.delete(ingredient);
   }
 }

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
@@ -27,7 +27,7 @@ export class IngredientService {
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._ingredientDataService.getMultiple(uid);
+          return this._ingredientDataService.getMany(uid);
         }
         return of([]);
       })

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
@@ -23,7 +23,7 @@ export type EditableMealData = Pick<
   providedIn: 'root',
 })
 export class MealDataService implements DtoService<Meal, MealDto> {
-  private _endpoint = Endpoint.meals;
+  private readonly _endpoint = Endpoint.meals;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
@@ -26,17 +26,17 @@ export class MealDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<MealDto>,
     private _dishUpdateService: DishUpdateService,
     private _tagUpdateService: TagUpdateService
   ) {}
 
   getMeal(id: string): Observable<MealDto | undefined> {
-    return this._dataService.getOne<MealDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getMeals(uid: string): Observable<MealDto[]> {
-    return this._dataService.getMany<MealDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createMeal(uid: string, meal: EditableMealData): Promise<string> {

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -8,6 +7,7 @@ import {
   TagUpdateService,
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
+  DtoService,
   MealDto,
   createMealDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
@@ -21,7 +21,7 @@ export type EditableMealData = Pick<
 @Injectable({
   providedIn: 'root',
 })
-export class MealDataService {
+export class MealDataService implements DtoService<Meal, MealDto> {
   private _endpoint = Endpoint.meals;
 
   constructor(
@@ -31,15 +31,15 @@ export class MealDataService {
     private _tagUpdateService: TagUpdateService
   ) {}
 
-  getMeal(id: string): Observable<MealDto | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMeals(uid: string): Observable<MealDto[]> {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createMeal(uid: string, meal: EditableMealData): Promise<string> {
+  async create(uid: string, meal: EditableMealData) {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -73,7 +73,7 @@ export class MealDataService {
     return id;
   }
 
-  async updateMeal(meal: Meal, data: EditableMealData): Promise<void> {
+  async update(meal: Meal, data: EditableMealData) {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -105,7 +105,7 @@ export class MealDataService {
     await batch.commit();
   }
 
-  async deleteMeal(meal: Meal): Promise<void> {
+  async delete(meal: Meal) {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, meal.id).updateMultiple([

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -31,15 +32,15 @@ export class MealDataService implements DtoService<Meal, MealDto> {
     private _tagUpdateService: TagUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<MealDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<MealDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, meal: EditableMealData) {
+  async create(uid: string, meal: EditableMealData): Promise<string> {
     const id = this._dataService.createId();
     const batch = this._batchService.createBatch();
 
@@ -73,7 +74,7 @@ export class MealDataService implements DtoService<Meal, MealDto> {
     return id;
   }
 
-  async update(meal: Meal, data: EditableMealData) {
+  async update(meal: Meal, data: EditableMealData): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.update({
@@ -105,7 +106,7 @@ export class MealDataService implements DtoService<Meal, MealDto> {
     await batch.commit();
   }
 
-  async delete(meal: Meal) {
+  async delete(meal: Meal): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, meal.id).updateMultiple([

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal.service.ts
@@ -28,7 +28,7 @@ export class MealService {
 
   getMeal(id: string): Observable<Meal | undefined> {
     return combineLatest([
-      this._mealDataService.getMeal(id),
+      this._mealDataService.getOne(id),
       this._dishService.getDishes(),
       this._tagService.getTags(),
     ]).pipe(
@@ -47,7 +47,7 @@ export class MealService {
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._mealDataService.getMeals(uid),
+            this._mealDataService.getMany(uid),
             this._dishService.getDishes(),
             this._tagService.getTags(),
           ]).pipe(
@@ -68,7 +68,7 @@ export class MealService {
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._mealDataService.createMeal(uid, meal);
+          const id = await this._mealDataService.create(uid, meal);
           return id;
         } else {
           return undefined;
@@ -78,10 +78,10 @@ export class MealService {
   }
 
   async updateMeal(meal: Meal, data: EditableMealData): Promise<void> {
-    return this._mealDataService.updateMeal(meal, data);
+    return this._mealDataService.update(meal, data);
   }
 
   async deleteMeal(meal: Meal): Promise<void> {
-    return this._mealDataService.deleteMeal(meal);
+    return this._mealDataService.delete(meal);
   }
 }

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
@@ -20,7 +20,7 @@ export type EditableMenuData = Partial<Pick<MenuDto, 'name' | 'startDay'>>;
   providedIn: 'root',
 })
 export class MenuDataService implements DtoService<Menu, MenuDto> {
-  private _endpoint = Endpoint.menus;
+  private readonly _endpoint = Endpoint.menus;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -8,6 +7,7 @@ import {
   MenuUpdateService,
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
+  DtoService,
   MenuDto,
   createMenuDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
@@ -18,7 +18,7 @@ export type EditableMenuData = Partial<Pick<MenuDto, 'name' | 'startDay'>>;
 @Injectable({
   providedIn: 'root',
 })
-export class MenuDataService {
+export class MenuDataService implements DtoService<Menu, MenuDto> {
   private _endpoint = Endpoint.menus;
 
   constructor(
@@ -28,15 +28,15 @@ export class MenuDataService {
     private _menuUpdateService: MenuUpdateService
   ) {}
 
-  getMenu(id: string): Observable<MenuDto | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMenus(uid: string): Observable<MenuDto[]> {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createMenu(uid: string, menu: EditableMenuData): Promise<string> {
+  async create(uid: string, menu: EditableMenuData) {
     const id = this._dataService.createId();
 
     await this._dataService.create(
@@ -52,7 +52,7 @@ export class MenuDataService {
     return id;
   }
 
-  async updateMenu(id: string, data: EditableMenuData): Promise<void> {
+  async update({ id }: Menu, data: EditableMenuData) {
     return await this._dataService.update(this._endpoint, id, data);
   }
 
@@ -86,7 +86,7 @@ export class MenuDataService {
     await batch.commit();
   }
 
-  async deleteMenu(menu: Menu): Promise<void> {
+  async delete(menu: Menu) {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, menu.id).updateMultiple(
@@ -100,7 +100,7 @@ export class MenuDataService {
     await batch.commit();
   }
 
-  async deleteMenuContents(menu: Menu, day?: Day): Promise<void> {
+  async deleteMenuContents(menu: Menu, day?: Day) {
     const batch = this._batchService.createBatch();
 
     // Clear a single day's contents

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -28,15 +29,15 @@ export class MenuDataService implements DtoService<Menu, MenuDto> {
     private _menuUpdateService: MenuUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<MenuDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<MenuDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, menu: EditableMenuData) {
+  async create(uid: string, menu: EditableMenuData): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create(
@@ -52,7 +53,7 @@ export class MenuDataService implements DtoService<Menu, MenuDto> {
     return id;
   }
 
-  async update({ id }: Menu, data: EditableMenuData) {
+  async update({ id }: Menu, data: EditableMenuData): Promise<void> {
     return await this._dataService.update(this._endpoint, id, data);
   }
 
@@ -86,7 +87,7 @@ export class MenuDataService implements DtoService<Menu, MenuDto> {
     await batch.commit();
   }
 
-  async delete(menu: Menu) {
+  async delete(menu: Menu): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, menu.id).updateMultiple(
@@ -100,7 +101,7 @@ export class MenuDataService implements DtoService<Menu, MenuDto> {
     await batch.commit();
   }
 
-  async deleteMenuContents(menu: Menu, day?: Day) {
+  async deleteMenuContents(menu: Menu, day?: Day): Promise<void> {
     const batch = this._batchService.createBatch();
 
     // Clear a single day's contents

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu-data.service.ts
@@ -23,23 +23,23 @@ export class MenuDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<MenuDto>,
     private _dishUpdateService: DishUpdateService,
     private _menuUpdateService: MenuUpdateService
   ) {}
 
   getMenu(id: string): Observable<MenuDto | undefined> {
-    return this._dataService.getOne<MenuDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getMenus(uid: string): Observable<MenuDto[]> {
-    return this._dataService.getMany<MenuDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createMenu(uid: string, menu: EditableMenuData): Promise<string> {
     const id = this._dataService.createId();
 
-    await this._dataService.create<MenuDto>(
+    await this._dataService.create(
       this._endpoint,
       id,
       createMenuDto({
@@ -53,7 +53,7 @@ export class MenuDataService {
   }
 
   async updateMenu(id: string, data: EditableMenuData): Promise<void> {
-    return await this._dataService.update<MenuDto>(this._endpoint, id, data);
+    return await this._dataService.update(this._endpoint, id, data);
   }
 
   async updateMenuContents({

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu.service.ts
@@ -26,7 +26,7 @@ export class MenuService {
 
   getMenu(id: string): Observable<Menu | undefined> {
     return combineLatest([
-      this._menuDataService.getMenu(id),
+      this._menuDataService.getOne(id),
       this._dishService.getDishes(),
       this._userService.getPreferences(),
     ]).pipe(
@@ -45,7 +45,7 @@ export class MenuService {
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._menuDataService.getMenus(uid),
+            this._menuDataService.getMany(uid),
             this._dishService.getDishes(),
             this._userService.getPreferences(),
           ]).pipe(
@@ -69,7 +69,7 @@ export class MenuService {
       first(),
       concatMap(async (user) => {
         if (user) {
-          const id = await this._menuDataService.createMenu(user.uid, {
+          const id = await this._menuDataService.create(user.uid, {
             name,
             startDay: user.preferences.defaultMenuStartDay,
           });
@@ -81,12 +81,12 @@ export class MenuService {
     );
   }
 
-  async updateMenuName(id: string, name: string): Promise<void> {
-    return this._menuDataService.updateMenu(id, { name });
+  async updateMenuName(menu: Menu, name: string): Promise<void> {
+    return this._menuDataService.update(menu, { name });
   }
 
-  async updateMenuStartDay(id: string, startDay: Day): Promise<void> {
-    return this._menuDataService.updateMenu(id, { startDay });
+  async updateMenuStartDay(menu: Menu, startDay: Day): Promise<void> {
+    return this._menuDataService.update(menu, { startDay });
   }
 
   async updateMenuContents({
@@ -109,7 +109,7 @@ export class MenuService {
   }
 
   async deleteMenu(menu: Menu): Promise<void> {
-    return this._menuDataService.deleteMenu(menu);
+    return this._menuDataService.delete(menu);
   }
 
   async deleteMenuContents(menu: Menu, day?: Day): Promise<void> {

--- a/libs/menu-matriarch/menus/feature/src/lib/menus.component.html
+++ b/libs/menu-matriarch/menus/feature/src/lib/menus.component.html
@@ -28,8 +28,8 @@
       [canDelete]="vm.menus.length > 1"
       [active]="menu.id === vm.activeMenuId"
       (print)="onPrint(menu)"
-      (rename)="onRename(menu.id, $event)"
-      (startDayChange)="onStartDayChange(menu.id, $event)"
+      (rename)="onRename(menu, $event)"
+      (startDayChange)="onStartDayChange(menu, $event)"
       (delete)="onDelete(menu)"
     ></li>
   </ul>

--- a/libs/menu-matriarch/menus/feature/src/lib/menus.component.ts
+++ b/libs/menu-matriarch/menus/feature/src/lib/menus.component.ts
@@ -59,12 +59,12 @@ export class MenusComponent {
     });
   }
 
-  onRename(id: string, name: string): void {
-    this._menuService.updateMenuName(id, name);
+  onRename(menu: Menu, name: string): void {
+    this._menuService.updateMenuName(menu, name);
   }
 
-  onStartDayChange(id: string, startDay: Day): void {
-    this._menuService.updateMenuStartDay(id, startDay);
+  onStartDayChange(menu: Menu, startDay: Day): void {
+    this._menuService.updateMenuStartDay(menu, startDay);
   }
 
   onDelete(menu: Menu): void {

--- a/libs/menu-matriarch/settings/data-access/src/lib/user-data.service.ts
+++ b/libs/menu-matriarch/settings/data-access/src/lib/user-data.service.ts
@@ -11,7 +11,7 @@ import { User, UserPreferences } from '@atocha/menu-matriarch/shared/util';
   providedIn: 'root',
 })
 export class UserDataService {
-  private _endpoint = Endpoint.users;
+  private readonly _endpoint = Endpoint.users;
 
   constructor(private _dataService: DataService<UserDto>) {}
 

--- a/libs/menu-matriarch/settings/data-access/src/lib/user-data.service.ts
+++ b/libs/menu-matriarch/settings/data-access/src/lib/user-data.service.ts
@@ -13,10 +13,10 @@ import { User, UserPreferences } from '@atocha/menu-matriarch/shared/util';
 export class UserDataService {
   private _endpoint = Endpoint.users;
 
-  constructor(private _dataService: DataService) {}
+  constructor(private _dataService: DataService<UserDto>) {}
 
   getUser(uid: string): Observable<User | undefined> {
-    return this._dataService.getOne<UserDto>(this._endpoint, uid);
+    return this._dataService.getOne(this._endpoint, uid);
   }
 
   getPreferences(uid: string): Observable<UserPreferences | undefined> {
@@ -27,7 +27,7 @@ export class UserDataService {
     { uid, preferences }: User,
     data: Partial<UserPreferences>
   ): Promise<void> {
-    return this._dataService.update<UserDto>(this._endpoint, uid, {
+    return this._dataService.update(this._endpoint, uid, {
       preferences: {
         ...preferences,
         ...data,

--- a/libs/menu-matriarch/shared/data-access-dtos/src/index.ts
+++ b/libs/menu-matriarch/shared/data-access-dtos/src/index.ts
@@ -1,3 +1,5 @@
+export * from './lib/dto-service.interface';
+
 export * from './lib/dish-dto';
 export * from './lib/ingredient-dto';
 export * from './lib/ingredient-type-dto';

--- a/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
@@ -1,8 +1,8 @@
 import { Observable } from 'rxjs';
 
-export interface DtoService<TEntity, TData = Partial<TEntity>> {
-  getOne(id: string): Observable<TEntity | undefined>;
-  getMany(uid: string): Observable<TEntity[]>;
+export interface DtoService<TEntity, TDto, TData = Partial<TEntity>> {
+  getOne(id: string): Observable<TDto | undefined>;
+  getMany(uid: string): Observable<TDto[]>;
   create(uid: string, data: TData): Promise<string>;
   update(item: TEntity, data: TData): Promise<void>;
   delete(item: TEntity): Promise<void>;

--- a/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
@@ -1,9 +1,9 @@
 import { Observable } from 'rxjs';
 
-export interface DtoService<T> {
-  getOne(id: string): Observable<T | undefined>;
-  getMultiple(uid: string): Observable<T[]>;
-  create(uid: string, data: Partial<T>): Promise<string>;
-  update(item: T, data: Partial<T>): Promise<void>;
-  delete(item: T): Promise<void>;
+export interface DtoService<TEntity, TData = Partial<TEntity>> {
+  getOne(id: string): Observable<TEntity | undefined>;
+  getMultiple(uid: string): Observable<TEntity[]>;
+  create(uid: string, data: TData): Promise<string>;
+  update(item: TEntity, data: TData): Promise<void>;
+  delete(item: TEntity): Promise<void>;
 }

--- a/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 
 export interface DtoService<TEntity, TData = Partial<TEntity>> {
   getOne(id: string): Observable<TEntity | undefined>;
-  getMultiple(uid: string): Observable<TEntity[]>;
+  getMany(uid: string): Observable<TEntity[]>;
   create(uid: string, data: TData): Promise<string>;
   update(item: TEntity, data: TData): Promise<void>;
   delete(item: TEntity): Promise<void>;

--- a/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-dtos/src/lib/dto-service.interface.ts
@@ -1,0 +1,9 @@
+import { Observable } from 'rxjs';
+
+export interface DtoService<T> {
+  getOne(id: string): Observable<T | undefined>;
+  getMultiple(uid: string): Observable<T[]>;
+  create(uid: string, data: Partial<T>): Promise<string>;
+  update(item: T, data: Partial<T>): Promise<void>;
+  delete(item: T): Promise<void>;
+}

--- a/libs/menu-matriarch/shell/data-access/src/lib/seed-data.service.ts
+++ b/libs/menu-matriarch/shell/data-access/src/lib/seed-data.service.ts
@@ -9,7 +9,7 @@ import { SeedData } from './seed-data/seed-data';
 export class SeedDataService {
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService
+    private _dataService: DataService<unknown>
   ) {}
 
   async createUserData({

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -28,15 +29,15 @@ export class TagDataService implements DtoService<Tag, TagDto> {
     private _mealUpdateService: MealUpdateService
   ) {}
 
-  getOne(id: string) {
+  getOne(id: string): Observable<TagDto | undefined> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string) {
+  getMany(uid: string): Observable<TagDto[]> {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async create(uid: string, tag: EditableTagData) {
+  async create(uid: string, tag: EditableTagData): Promise<string> {
     const id = this._dataService.createId();
 
     await this._dataService.create(
@@ -48,11 +49,11 @@ export class TagDataService implements DtoService<Tag, TagDto> {
     return id;
   }
 
-  async update(tag: Tag, data: EditableTagData) {
+  async update(tag: Tag, data: EditableTagData): Promise<void> {
     return this._dataService.update(this._endpoint, tag.id, data);
   }
 
-  async delete(tag: Tag) {
+  async delete(tag: Tag): Promise<void> {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, tag.id).updateMultiple([

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
 import { BatchService, DataService } from '@atocha/firebase/data-access';
 import {
@@ -8,6 +7,7 @@ import {
   MealUpdateService,
 } from '@atocha/menu-matriarch/shared/data-access-api';
 import {
+  DtoService,
   TagDto,
   createTagDto,
 } from '@atocha/menu-matriarch/shared/data-access-dtos';
@@ -18,7 +18,7 @@ export type EditableTagData = Pick<TagDto, 'name'>;
 @Injectable({
   providedIn: 'root',
 })
-export class TagDataService {
+export class TagDataService implements DtoService<TagDto> {
   private _endpoint = Endpoint.tags;
 
   constructor(
@@ -28,15 +28,15 @@ export class TagDataService {
     private _mealUpdateService: MealUpdateService
   ) {}
 
-  getTag(id: string): Observable<Tag | undefined> {
+  getOne(id: string) {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getTags(uid: string): Observable<Tag[]> {
+  getMultiple(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 
-  async createTag(uid: string, tag: EditableTagData): Promise<string> {
+  async create(uid: string, tag: EditableTagData) {
     const id = this._dataService.createId();
 
     await this._dataService.create(
@@ -48,11 +48,11 @@ export class TagDataService {
     return id;
   }
 
-  async updateTag(tag: Tag, data: EditableTagData): Promise<void> {
+  async update(tag: Tag, data: EditableTagData) {
     return this._dataService.update(this._endpoint, tag.id, data);
   }
 
-  async deleteTag(tag: Tag): Promise<void> {
+  async delete(tag: Tag) {
     const batch = this._batchService.createBatch();
 
     batch.delete(this._endpoint, tag.id).updateMultiple([

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -20,7 +20,7 @@ export type EditableTagData = Pick<TagDto, 'name'>;
   providedIn: 'root',
 })
 export class TagDataService implements DtoService<Tag, TagDto> {
-  private _endpoint = Endpoint.tags;
+  private readonly _endpoint = Endpoint.tags;
 
   constructor(
     private _batchService: BatchService,

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -32,7 +32,7 @@ export class TagDataService implements DtoService<TagDto> {
     return this._dataService.getOne(this._endpoint, id);
   }
 
-  getMultiple(uid: string) {
+  getMany(uid: string) {
     return this._dataService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -23,23 +23,23 @@ export class TagDataService {
 
   constructor(
     private _batchService: BatchService,
-    private _dataService: DataService,
+    private _dataService: DataService<TagDto>,
     private _dishUpdateService: DishUpdateService,
     private _mealUpdateService: MealUpdateService
   ) {}
 
   getTag(id: string): Observable<Tag | undefined> {
-    return this._dataService.getOne<TagDto>(this._endpoint, id);
+    return this._dataService.getOne(this._endpoint, id);
   }
 
   getTags(uid: string): Observable<Tag[]> {
-    return this._dataService.getMany<TagDto>(this._endpoint, uid);
+    return this._dataService.getMany(this._endpoint, uid);
   }
 
   async createTag(uid: string, tag: EditableTagData): Promise<string> {
     const id = this._dataService.createId();
 
-    await this._dataService.create<TagDto>(
+    await this._dataService.create(
       this._endpoint,
       id,
       createTagDto({ id, uid, ...tag })
@@ -49,7 +49,7 @@ export class TagDataService {
   }
 
   async updateTag(tag: Tag, data: EditableTagData): Promise<void> {
-    return this._dataService.update<TagDto>(this._endpoint, tag.id, data);
+    return this._dataService.update(this._endpoint, tag.id, data);
   }
 
   async deleteTag(tag: Tag): Promise<void> {

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag-data.service.ts
@@ -18,7 +18,7 @@ export type EditableTagData = Pick<TagDto, 'name'>;
 @Injectable({
   providedIn: 'root',
 })
-export class TagDataService implements DtoService<TagDto> {
+export class TagDataService implements DtoService<Tag, TagDto> {
   private _endpoint = Endpoint.tags;
 
   constructor(

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
@@ -24,7 +24,7 @@ export class TagService {
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._tagDataService.getMultiple(uid);
+          return this._tagDataService.getMany(uid);
         }
         return of([]);
       })

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
@@ -16,7 +16,7 @@ export class TagService {
   ) {}
 
   getTag(id: string): Observable<Tag | undefined> {
-    return this._tagDataService.getTag(id);
+    return this._tagDataService.getOne(id);
   }
 
   getTags(): Observable<Tag[]> {
@@ -24,7 +24,7 @@ export class TagService {
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._tagDataService.getTags(uid);
+          return this._tagDataService.getMultiple(uid);
         }
         return of([]);
       })
@@ -36,7 +36,7 @@ export class TagService {
       first(),
       concatMap(async (uid) => {
         if (uid) {
-          const id = await this._tagDataService.createTag(uid, tag);
+          const id = await this._tagDataService.create(uid, tag);
           return id;
         } else {
           return undefined;
@@ -46,10 +46,10 @@ export class TagService {
   }
 
   async updateTag(tag: Tag, data: EditableTagData): Promise<void> {
-    return this._tagDataService.updateTag(tag, data);
+    return this._tagDataService.update(tag, data);
   }
 
   async deleteTag(tag: Tag): Promise<void> {
-    return this._tagDataService.deleteTag(tag);
+    return this._tagDataService.delete(tag);
   }
 }


### PR DESCRIPTION
1. Moves type generic in the foundational `DataService` from the `firebase-data-access` lib from the method level to the class level
2. Creates `DtoService` interface and implements it in all entity data services
3. Adds `readonly` modifier to all private endpoint properties in services