### PR TITLE
Derive SI types from data

### DIFF
--- a/libs/spirit-islander/util/src/lib/app/create-model.ts
+++ b/libs/spirit-islander/util/src/lib/app/create-model.ts
@@ -3,9 +3,10 @@ import type { BalancedBoardName } from '../game/boards';
 import type { MapName } from '../game/maps';
 import type { ScenarioName } from '../game/scenarios';
 import type { SpiritName } from '../game/spirits';
-import type { ExpansionName, ExpansionOption } from '../game/expansions';
+import type { ExpansionName } from '../game/expansions';
 import { getOptionsByExpansion } from '../game/get-options-by-expansion';
 import { Options } from '../game/options';
+import { ExpansionOption } from '../game/option';
 
 export function createSpiritsModel(
   expansions: readonly ExpansionName[] = []

--- a/libs/spirit-islander/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/util/src/lib/app/get-valid-combos.ts
@@ -1,10 +1,10 @@
-import type { DifficultyOption } from '../game/difficulty';
 import { Map, MapName } from '../game/maps';
 import { Scenario, ScenarioName } from '../game/scenarios';
 import { AdversaryLevel, AdversaryLevelName } from '../game/adversaries';
 import { getDifficulty } from '../game/get-difficulty';
 import { ComboAnalyzer } from './combo-analyzer';
 import type { Config } from './config.interface';
+import { DifficultyOption } from '../game/option';
 import { Options } from '../game/options';
 
 const comboAnalyzer = new ComboAnalyzer<

--- a/libs/spirit-islander/util/src/lib/game/adversaries.ts
+++ b/libs/spirit-islander/util/src/lib/game/adversaries.ts
@@ -1,3 +1,4 @@
+import { ADVERSARIES } from './data';
 import type { DifficultyOption } from './difficulty';
 import type { ExpansionOption } from './expansions';
 
@@ -5,78 +6,14 @@ export interface Adversary extends ExpansionOption<AdversaryName> {
   levels: readonly AdversaryLevel[];
 }
 
-export type AdversaryName =
-  | 'No Adversary'
-  | 'Brandenburg-Prussia'
-  | 'France'
-  | 'England'
-  | 'Habsburg Monarchy'
-  | 'Russia'
-  | 'Scotland'
-  | 'Sweden';
+export type AdversaryName = (typeof ADVERSARIES)[number]['name'];
 
 export type AdversaryLevelName =
-  | 'N/A'
-  | 'Level 0'
-  | 'Level 1'
-  | 'Level 2'
-  | 'Level 3'
-  | 'Level 4'
-  | 'Level 5'
-  | 'Level 6';
+  (typeof ADVERSARIES)[number]['levels'][number]['name'];
+
+export type AdversaryLevelId =
+  (typeof ADVERSARIES)[number]['levels'][number]['id'];
 
 export interface AdversaryLevel extends DifficultyOption<AdversaryLevelName> {
   id: AdversaryLevelId;
 }
-
-export type AdversaryLevelId =
-  | 'none'
-  | 'bp-0'
-  | 'bp-1'
-  | 'bp-2'
-  | 'bp-3'
-  | 'bp-4'
-  | 'bp-5'
-  | 'bp-6'
-  | 'en-0'
-  | 'en-1'
-  | 'en-2'
-  | 'en-3'
-  | 'en-4'
-  | 'en-5'
-  | 'en-6'
-  | 'fr-0'
-  | 'fr-1'
-  | 'fr-2'
-  | 'fr-3'
-  | 'fr-4'
-  | 'fr-5'
-  | 'fr-6'
-  | 'hm-0'
-  | 'hm-1'
-  | 'hm-2'
-  | 'hm-3'
-  | 'hm-4'
-  | 'hm-5'
-  | 'hm-6'
-  | 'ru-0'
-  | 'ru-1'
-  | 'ru-2'
-  | 'ru-3'
-  | 'ru-4'
-  | 'ru-5'
-  | 'ru-6'
-  | 'sc-0'
-  | 'sc-1'
-  | 'sc-2'
-  | 'sc-3'
-  | 'sc-4'
-  | 'sc-5'
-  | 'sc-6'
-  | 'sw-0'
-  | 'sw-1'
-  | 'sw-2'
-  | 'sw-3'
-  | 'sw-4'
-  | 'sw-5'
-  | 'sw-6';

--- a/libs/spirit-islander/util/src/lib/game/adversaries.ts
+++ b/libs/spirit-islander/util/src/lib/game/adversaries.ts
@@ -1,6 +1,5 @@
 import { ADVERSARIES } from './data';
-import type { DifficultyOption } from './difficulty';
-import type { ExpansionOption } from './expansions';
+import { ExpansionOption, DifficultyOption } from './option';
 
 export interface Adversary extends ExpansionOption<AdversaryName> {
   levels: readonly AdversaryLevel[];

--- a/libs/spirit-islander/util/src/lib/game/boards.ts
+++ b/libs/spirit-islander/util/src/lib/game/boards.ts
@@ -1,5 +1,5 @@
 import { BOARDS } from './data';
-import type { ExpansionOption } from './expansions';
+import { ExpansionOption } from './option';
 
 export interface Board extends ExpansionOption<BalancedBoardName> {
   thematicName: ThematicBoardName;

--- a/libs/spirit-islander/util/src/lib/game/boards.ts
+++ b/libs/spirit-islander/util/src/lib/game/boards.ts
@@ -1,15 +1,10 @@
+import { BOARDS } from './data';
 import type { ExpansionOption } from './expansions';
 
 export interface Board extends ExpansionOption<BalancedBoardName> {
   thematicName: ThematicBoardName;
 }
 
-export type BalancedBoardName = 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+export type BalancedBoardName = (typeof BOARDS)[number]['name'];
 
-export type ThematicBoardName =
-  | 'Northeast'
-  | 'East'
-  | 'Northwest'
-  | 'West'
-  | 'Southeast'
-  | 'Southwest';
+export type ThematicBoardName = (typeof BOARDS)[number]['thematicName'];

--- a/libs/spirit-islander/util/src/lib/game/data/adversaries.ts
+++ b/libs/spirit-islander/util/src/lib/game/data/adversaries.ts
@@ -1,6 +1,4 @@
-import { Adversary } from '../adversaries';
-
-export const ADVERSARIES: readonly Adversary[] = [
+export const ADVERSARIES = [
   {
     name: 'No Adversary',
     levels: [{ id: 'none', name: 'N/A', difficulty: 0 }],
@@ -93,4 +91,4 @@ export const ADVERSARIES: readonly Adversary[] = [
       { id: 'sw-6', name: 'Level 6', difficulty: 8 },
     ],
   },
-];
+] as const;

--- a/libs/spirit-islander/util/src/lib/game/data/boards.ts
+++ b/libs/spirit-islander/util/src/lib/game/data/boards.ts
@@ -1,6 +1,4 @@
-import { Board } from '../boards';
-
-export const BOARDS: readonly Board[] = [
+export const BOARDS = [
   {
     name: 'A',
     thematicName: 'Northeast',
@@ -27,4 +25,4 @@ export const BOARDS: readonly Board[] = [
     thematicName: 'Southwest',
     expansion: 'Jagged Earth',
   },
-];
+] as const;

--- a/libs/spirit-islander/util/src/lib/game/data/maps.ts
+++ b/libs/spirit-islander/util/src/lib/game/data/maps.ts
@@ -1,13 +1,13 @@
-import { Map } from '../maps';
+import { ExpansionName } from '../expansions';
 
-export const MAPS: readonly Map[] = [
+export const MAPS = [
   {
     name: 'Balanced',
     difficulty: 0,
   },
   {
     name: 'Thematic',
-    difficulty: (expansions) => {
+    difficulty: (expansions: readonly ExpansionName[]) => {
       return expansions.some(
         (expansion) =>
           expansion === 'Branch & Claw' || expansion === 'Jagged Earth'

--- a/libs/spirit-islander/util/src/lib/game/data/scenarios.ts
+++ b/libs/spirit-islander/util/src/lib/game/data/scenarios.ts
@@ -1,6 +1,4 @@
-import { Scenario } from '../scenarios';
-
-export const SCENARIOS: readonly Scenario[] = [
+export const SCENARIOS = [
   {
     name: 'No Scenario',
     difficulty: 0,
@@ -66,4 +64,4 @@ export const SCENARIOS: readonly Scenario[] = [
     name: 'Dahan Insurrection',
     difficulty: 4,
   },
-];
+] as const;

--- a/libs/spirit-islander/util/src/lib/game/data/spirits.ts
+++ b/libs/spirit-islander/util/src/lib/game/data/spirits.ts
@@ -1,6 +1,4 @@
-import { Spirit } from '../spirits';
-
-export const SPIRITS: readonly Spirit[] = [
+export const SPIRITS = [
   { name: 'A Spread of Rampant Green' },
   { name: 'Bringer of Dreams and Nightmares' },
   { name: 'Devouring Teeth Lurk Underfoot', expansion: 'Horizons' },
@@ -30,4 +28,4 @@ export const SPIRITS: readonly Spirit[] = [
   { name: 'Vengeance as a Burning Plague', expansion: 'Jagged Earth' },
   { name: 'Vital Strength of the Earth' },
   { name: 'Volcano Looming High', expansion: 'Jagged Earth' },
-];
+] as const;

--- a/libs/spirit-islander/util/src/lib/game/difficulty.ts
+++ b/libs/spirit-islander/util/src/lib/game/difficulty.ts
@@ -1,11 +1,3 @@
 import { DIFFICULTIES } from './data';
-import type { ExpansionName } from './expansions';
-import type { Option } from './option';
 
 export type Difficulty = (typeof DIFFICULTIES)[number];
-
-export interface DifficultyOption<TName extends string> extends Option<TName> {
-  difficulty:
-    | Difficulty
-    | ((expansions: readonly ExpansionName[]) => Difficulty);
-}

--- a/libs/spirit-islander/util/src/lib/game/expansions.ts
+++ b/libs/spirit-islander/util/src/lib/game/expansions.ts
@@ -1,8 +1,3 @@
 import { EXPANSIONS } from './data';
-import type { Option } from './option';
 
 export type ExpansionName = (typeof EXPANSIONS)[number];
-
-export interface ExpansionOption<TName extends string> extends Option<TName> {
-  expansion?: ExpansionName;
-}

--- a/libs/spirit-islander/util/src/lib/game/get-difficulty.spec.ts
+++ b/libs/spirit-islander/util/src/lib/game/get-difficulty.spec.ts
@@ -1,5 +1,5 @@
-import type { DifficultyOption } from './difficulty';
 import { getDifficulty } from './get-difficulty';
+import { DifficultyOption } from './option';
 
 describe('getDifficulty', () => {
   it('returns static difficulty value', () => {

--- a/libs/spirit-islander/util/src/lib/game/get-options-by-expansion.ts
+++ b/libs/spirit-islander/util/src/lib/game/get-options-by-expansion.ts
@@ -1,4 +1,5 @@
-import type { ExpansionName, ExpansionOption } from './expansions';
+import type { ExpansionName } from './expansions';
+import { ExpansionOption } from './option';
 
 /**
  * Get options from base game and specified expansions

--- a/libs/spirit-islander/util/src/lib/game/maps.ts
+++ b/libs/spirit-islander/util/src/lib/game/maps.ts
@@ -1,3 +1,4 @@
+import { MAPS } from './data';
 import type { DifficultyOption } from './difficulty';
 import type { ExpansionOption } from './expansions';
 
@@ -5,4 +6,4 @@ export interface Map
   extends DifficultyOption<MapName>,
     ExpansionOption<MapName> {}
 
-export type MapName = 'Balanced' | 'Thematic';
+export type MapName = (typeof MAPS)[number]['name'];

--- a/libs/spirit-islander/util/src/lib/game/maps.ts
+++ b/libs/spirit-islander/util/src/lib/game/maps.ts
@@ -1,6 +1,5 @@
 import { MAPS } from './data';
-import type { DifficultyOption } from './difficulty';
-import type { ExpansionOption } from './expansions';
+import { DifficultyOption, ExpansionOption } from './option';
 
 export interface Map
   extends DifficultyOption<MapName>,

--- a/libs/spirit-islander/util/src/lib/game/option.ts
+++ b/libs/spirit-islander/util/src/lib/game/option.ts
@@ -1,3 +1,16 @@
+import { Difficulty } from './difficulty';
+import { ExpansionName } from './expansions';
+
 export interface Option<T extends string> {
   name: T;
+}
+
+export interface DifficultyOption<TName extends string> extends Option<TName> {
+  difficulty:
+    | Difficulty
+    | ((expansions: readonly ExpansionName[]) => Difficulty);
+}
+
+export interface ExpansionOption<TName extends string> extends Option<TName> {
+  expansion?: ExpansionName;
 }

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -22,7 +22,7 @@ export class Options {
   static allPlayers = PLAYERS;
   static allSpirits = SPIRITS;
   static allSpiritNames = SPIRITS.map(({ name }) => name);
-  static allBoards = BOARDS;
+  static allBoards: readonly Board[] = BOARDS;
   static allBoardNames = BOARDS.map(({ name }) => name);
   static allMaps = MAPS;
   static allMapNames = MAPS.map(({ name }) => name);
@@ -39,8 +39,8 @@ export class Options {
     return this._spirits.map(({ name }) => name);
   }
 
-  private _boards = BOARDS;
-  get boards(): readonly Board[] {
+  private _boards: readonly Board[] = BOARDS;
+  get boards() {
     return this._boards;
   }
   get boardNames(): readonly BalancedBoardName[] {

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -24,7 +24,7 @@ export class Options {
   static allSpiritNames = SPIRITS.map(({ name }) => name);
   static allBoards: readonly Board[] = BOARDS;
   static allBoardNames = BOARDS.map(({ name }) => name);
-  static allMaps = MAPS;
+  static allMaps: readonly Map[] = MAPS;
   static allMapNames = MAPS.map(({ name }) => name);
   static allScenarios = SCENARIOS;
   static allScenarioNames = SCENARIOS.map(({ name }) => name);
@@ -47,8 +47,8 @@ export class Options {
     return this._boards.map(({ name }) => name);
   }
 
-  private _maps = MAPS;
-  get maps(): readonly Map[] {
+  private _maps: readonly Map[] = MAPS;
+  get maps() {
     return this._maps;
   }
   get mapNames(): readonly MapName[] {

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -20,7 +20,7 @@ export class Options {
   static allExpansions = EXPANSIONS;
   static allDifficulties = DIFFICULTIES;
   static allPlayers = PLAYERS;
-  static allSpirits = SPIRITS;
+  static allSpirits: readonly Spirit[] = SPIRITS;
   static allSpiritNames = SPIRITS.map(({ name }) => name);
   static allBoards: readonly Board[] = BOARDS;
   static allBoardNames = BOARDS.map(({ name }) => name);
@@ -31,8 +31,8 @@ export class Options {
   static allAdversaries: readonly Adversary[] = ADVERSARIES;
   static allAdversaryLevelIds = getAdversaryLevelIds(this.allAdversaries);
 
-  private _spirits = SPIRITS;
-  get spirits(): readonly Spirit[] {
+  private _spirits: readonly Spirit[] = SPIRITS;
+  get spirits() {
     return this._spirits;
   }
   get spiritNames(): readonly SpiritName[] {

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -1,25 +1,27 @@
 import {
-  EXPANSIONS,
-  DIFFICULTIES,
-  PLAYERS,
-  SPIRITS,
-  BOARDS,
-  MAPS,
-  SCENARIOS,
   ADVERSARIES,
+  BOARDS,
+  DIFFICULTIES,
+  EXPANSIONS,
+  MAPS,
+  PLAYERS,
+  SCENARIOS,
+  SPIRITS,
 } from './data';
 import { Adversary, AdversaryLevelId } from './adversaries';
 import { BalancedBoardName, Board } from './boards';
+import { Difficulty } from './difficulty';
 import { ExpansionName } from './expansions';
 import { Map, MapName } from './maps';
+import { Players } from './players';
 import { Scenario, ScenarioName } from './scenarios';
 import { Spirit, SpiritName } from './spirits';
 import { getOptionsByExpansion } from './get-options-by-expansion';
 
 export class Options {
-  static allExpansions = EXPANSIONS;
-  static allDifficulties = DIFFICULTIES;
-  static allPlayers = PLAYERS;
+  static allExpansions: readonly ExpansionName[] = EXPANSIONS;
+  static allDifficulties: readonly Difficulty[] = DIFFICULTIES;
+  static allPlayers: readonly Players[] = PLAYERS;
   static allSpirits: readonly Spirit[] = SPIRITS;
   static allSpiritNames = SPIRITS.map(({ name }) => name);
   static allBoards: readonly Board[] = BOARDS;

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -26,7 +26,7 @@ export class Options {
   static allBoardNames = BOARDS.map(({ name }) => name);
   static allMaps: readonly Map[] = MAPS;
   static allMapNames = MAPS.map(({ name }) => name);
-  static allScenarios = SCENARIOS;
+  static allScenarios: readonly Scenario[] = SCENARIOS;
   static allScenarioNames = SCENARIOS.map(({ name }) => name);
   static allAdversaries: readonly Adversary[] = ADVERSARIES;
   static allAdversaryLevelIds = getAdversaryLevelIds(this.allAdversaries);
@@ -55,8 +55,8 @@ export class Options {
     return this._maps.map(({ name }) => name);
   }
 
-  private _scenarios = SCENARIOS;
-  get scenarios(): readonly Scenario[] {
+  private _scenarios: readonly Scenario[] = SCENARIOS;
+  get scenarios() {
     return this._scenarios;
   }
   get scenarioNames(): readonly ScenarioName[] {

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -28,7 +28,7 @@ export class Options {
   static allMapNames = MAPS.map(({ name }) => name);
   static allScenarios = SCENARIOS;
   static allScenarioNames = SCENARIOS.map(({ name }) => name);
-  static allAdversaries = ADVERSARIES;
+  static allAdversaries: readonly Adversary[] = ADVERSARIES;
   static allAdversaryLevelIds = getAdversaryLevelIds(this.allAdversaries);
 
   private _spirits = SPIRITS;
@@ -63,8 +63,8 @@ export class Options {
     return this._scenarios.map(({ name }) => name);
   }
 
-  private _adversaries = ADVERSARIES;
-  get adversaries(): readonly Adversary[] {
+  private _adversaries: readonly Adversary[] = ADVERSARIES;
+  get adversaries() {
     return this._adversaries;
   }
   get adversaryLevelIds(): readonly AdversaryLevelId[] {

--- a/libs/spirit-islander/util/src/lib/game/options.ts
+++ b/libs/spirit-islander/util/src/lib/game/options.ts
@@ -16,6 +16,8 @@ import { Map, MapName } from './maps';
 import { Players } from './players';
 import { Scenario, ScenarioName } from './scenarios';
 import { Spirit, SpiritName } from './spirits';
+
+import { Option } from './option';
 import { getOptionsByExpansion } from './get-options-by-expansion';
 
 export class Options {
@@ -23,14 +25,15 @@ export class Options {
   static allDifficulties: readonly Difficulty[] = DIFFICULTIES;
   static allPlayers: readonly Players[] = PLAYERS;
   static allSpirits: readonly Spirit[] = SPIRITS;
-  static allSpiritNames = SPIRITS.map(({ name }) => name);
   static allBoards: readonly Board[] = BOARDS;
-  static allBoardNames = BOARDS.map(({ name }) => name);
   static allMaps: readonly Map[] = MAPS;
-  static allMapNames = MAPS.map(({ name }) => name);
   static allScenarios: readonly Scenario[] = SCENARIOS;
-  static allScenarioNames = SCENARIOS.map(({ name }) => name);
   static allAdversaries: readonly Adversary[] = ADVERSARIES;
+
+  static allSpiritNames = getNames(this.allSpirits);
+  static allBoardNames = getNames(this.allBoards);
+  static allMapNames = getNames(this.allMaps);
+  static allScenarioNames = getNames(this.allScenarios);
   static allAdversaryLevelIds = getAdversaryLevelIds(this.allAdversaries);
 
   private _spirits: readonly Spirit[] = SPIRITS;
@@ -38,7 +41,7 @@ export class Options {
     return this._spirits;
   }
   get spiritNames(): readonly SpiritName[] {
-    return this._spirits.map(({ name }) => name);
+    return getNames(this._spirits);
   }
 
   private _boards: readonly Board[] = BOARDS;
@@ -46,7 +49,7 @@ export class Options {
     return this._boards;
   }
   get boardNames(): readonly BalancedBoardName[] {
-    return this._boards.map(({ name }) => name);
+    return getNames(this._boards);
   }
 
   private _maps: readonly Map[] = MAPS;
@@ -54,7 +57,7 @@ export class Options {
     return this._maps;
   }
   get mapNames(): readonly MapName[] {
-    return this._maps.map(({ name }) => name);
+    return getNames(this._maps);
   }
 
   private _scenarios: readonly Scenario[] = SCENARIOS;
@@ -62,7 +65,7 @@ export class Options {
     return this._scenarios;
   }
   get scenarioNames(): readonly ScenarioName[] {
-    return this._scenarios.map(({ name }) => name);
+    return getNames(this._scenarios);
   }
 
   private _adversaries: readonly Adversary[] = ADVERSARIES;
@@ -87,6 +90,10 @@ export class Options {
       expansions
     );
   }
+}
+
+function getNames<TName extends string>(options: readonly Option<TName>[]) {
+  return options.map(({ name }) => name);
 }
 
 function getAdversaryLevelIds(adversaries: readonly Adversary[]) {

--- a/libs/spirit-islander/util/src/lib/game/scenarios.ts
+++ b/libs/spirit-islander/util/src/lib/game/scenarios.ts
@@ -1,6 +1,5 @@
 import { SCENARIOS } from './data';
-import type { DifficultyOption } from './difficulty';
-import type { ExpansionOption } from './expansions';
+import { DifficultyOption, ExpansionOption } from './option';
 
 export interface Scenario
   extends DifficultyOption<ScenarioName>,

--- a/libs/spirit-islander/util/src/lib/game/scenarios.ts
+++ b/libs/spirit-islander/util/src/lib/game/scenarios.ts
@@ -1,3 +1,4 @@
+import { SCENARIOS } from './data';
 import type { DifficultyOption } from './difficulty';
 import type { ExpansionOption } from './expansions';
 
@@ -5,18 +6,4 @@ export interface Scenario
   extends DifficultyOption<ScenarioName>,
     ExpansionOption<ScenarioName> {}
 
-export type ScenarioName =
-  | 'No Scenario'
-  | 'A Diversity of Spirits'
-  | 'Blitz'
-  | 'Dahan Insurrection'
-  | 'Despicable Theft'
-  | 'Elemental Invocation'
-  | "Guard the Isle's Heart"
-  | 'Powers Long Forgotten'
-  | 'Rituals of Destroying Flame'
-  | 'Rituals of Terror'
-  | 'Second Wave'
-  | 'The Great River'
-  | 'Varied Terrains'
-  | 'Ward the Shores';
+export type ScenarioName = (typeof SCENARIOS)[number]['name'];

--- a/libs/spirit-islander/util/src/lib/game/spirits.ts
+++ b/libs/spirit-islander/util/src/lib/game/spirits.ts
@@ -1,5 +1,5 @@
 import { SPIRITS } from './data';
-import { ExpansionOption } from './expansions';
+import { ExpansionOption } from './option';
 
 export type Spirit = ExpansionOption<SpiritName>;
 

--- a/libs/spirit-islander/util/src/lib/game/spirits.ts
+++ b/libs/spirit-islander/util/src/lib/game/spirits.ts
@@ -1,34 +1,6 @@
+import { SPIRITS } from './data';
 import { ExpansionOption } from './expansions';
 
 export type Spirit = ExpansionOption<SpiritName>;
 
-export type SpiritName =
-  | 'A Spread of Rampant Green'
-  | 'Bringer of Dreams and Nightmares'
-  | 'Devouring Teeth Lurk Underfoot'
-  | 'Downpour Drenches the World'
-  | 'Eyes Watch From the Trees'
-  | 'Fathomless Mud of the Swamp'
-  | 'Finder of Paths Unseen'
-  | 'Fractured Days Split the Sky'
-  | 'Grinning Trickster Stirs Up Trouble'
-  | 'Heart of the Wildfire'
-  | 'Keeper of the Forbidden Wilds'
-  | "Lightning's Swift Strike"
-  | 'Lure of the Deep Wilderness'
-  | 'Many Minds Move as One'
-  | "Ocean's Hungry Grasp"
-  | 'Rising Heat of Stone and Sand'
-  | 'River Surges in Sunlight'
-  | 'Serpent Slumbering Beneath the Island'
-  | 'Shadows Flicker Like Flame'
-  | 'Sharp Fangs Behind the Leaves'
-  | 'Shifting Memory of Ages'
-  | 'Shroud of Silent Mist'
-  | 'Sun-Bright Whirlwind'
-  | 'Starlight Seeks Its Form'
-  | "Stone's Unyielding Defiance"
-  | 'Thunderspeaker'
-  | 'Vengeance as a Burning Plague'
-  | 'Vital Strength of the Earth'
-  | 'Volcano Looming High';
+export type SpiritName = (typeof SPIRITS)[number]['name'];


### PR DESCRIPTION
1. Derives types from data rather than building data from types
2. Moves all `Option` interfaces to the same file
3. More concise logic in `Options` class