### PR TITLE
Create wrapper function for `ComboAnalyzer` implementation

### DIFF
--- a/libs/spirit-islander/shared/util/src/lib/app/combo-analyzer.spec.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/combo-analyzer.spec.ts
@@ -16,8 +16,8 @@ interface MockMap extends MockOption {
 
 describe('ComboAnalyzer', () => {
   let analyzer: ComboAnalyzer<MockOption>;
-  let adversaries: MockAdversary[];
-  let maps: MockMap[];
+  let adversaries: readonly MockAdversary[];
+  let maps: readonly MockMap[];
 
   beforeEach(() => {
     analyzer = new ComboAnalyzer<MockOption>();
@@ -75,15 +75,15 @@ describe('ComboAnalyzer', () => {
   });
 
   it('returns only combos that meet criteria', () => {
-    function isEasy(options: MockOption[]): boolean {
+    function isEasy(options: readonly MockOption[]): boolean {
       return getDifficulty(options) <= 2;
     }
 
-    function isHard(options: MockOption[]): boolean {
+    function isHard(options: readonly MockOption[]): boolean {
       return getDifficulty(options) >= 5;
     }
 
-    function getDifficulty(options: MockOption[]): number {
+    function getDifficulty(options: readonly MockOption[]): number {
       return options.reduce((accum, { difficulty }) => accum + difficulty, 0);
     }
 

--- a/libs/spirit-islander/shared/util/src/lib/app/combo-analyzer.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/combo-analyzer.ts
@@ -16,11 +16,22 @@ export class ComboAnalyzer<T> {
     T9 extends T,
     T10 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[], T9[], T10[]],
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[],
+      readonly T6[],
+      readonly T7[],
+      readonly T8[],
+      readonly T9[],
+      T10[]
+    ],
     isValidCombo?: (
-      options: [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
+      options: readonly [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
     ) => boolean
-  ): [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10][];
+  ): readonly [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10][];
   getPossibleCombos<
     T1 extends T,
     T2 extends T,
@@ -32,9 +43,21 @@ export class ComboAnalyzer<T> {
     T8 extends T,
     T9 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[], T9[]],
-    isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7, T8, T9]) => boolean
-  ): [T1, T2, T3, T4, T5, T6, T7, T8, T9][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[],
+      readonly T6[],
+      readonly T7[],
+      readonly T8[],
+      readonly T9[]
+    ],
+    isValidCombo?: (
+      options: readonly [T1, T2, T3, T4, T5, T6, T7, T8, T9]
+    ) => boolean
+  ): readonly [T1, T2, T3, T4, T5, T6, T7, T8, T9][];
   getPossibleCombos<
     T1 extends T,
     T2 extends T,
@@ -45,9 +68,20 @@ export class ComboAnalyzer<T> {
     T7 extends T,
     T8 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[]],
-    isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7, T8]) => boolean
-  ): [T1, T2, T3, T4, T5, T6, T7, T8][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[],
+      readonly T6[],
+      readonly T7[],
+      readonly T8[]
+    ],
+    isValidCombo?: (
+      options: readonly [T1, T2, T3, T4, T5, T6, T7, T8]
+    ) => boolean
+  ): readonly [T1, T2, T3, T4, T5, T6, T7, T8][];
   getPossibleCombos<
     T1 extends T,
     T2 extends T,
@@ -57,9 +91,17 @@ export class ComboAnalyzer<T> {
     T6 extends T,
     T7 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[]],
-    isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7]) => boolean
-  ): [T1, T2, T3, T4, T5, T6, T7][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[],
+      readonly T6[],
+      readonly T7[]
+    ],
+    isValidCombo?: (options: readonly [T1, T2, T3, T4, T5, T6, T7]) => boolean
+  ): readonly [T1, T2, T3, T4, T5, T6, T7][];
   getPossibleCombos<
     T1 extends T,
     T2 extends T,
@@ -68,9 +110,16 @@ export class ComboAnalyzer<T> {
     T5 extends T,
     T6 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[], T6[]],
-    isValidCombo?: (options: [T1, T2, T3, T4, T5, T6]) => boolean
-  ): [T1, T2, T3, T4, T5, T6][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[],
+      readonly T6[]
+    ],
+    isValidCombo?: (options: readonly [T1, T2, T3, T4, T5, T6]) => boolean
+  ): readonly [T1, T2, T3, T4, T5, T6][];
   getPossibleCombos<
     T1 extends T,
     T2 extends T,
@@ -78,43 +127,57 @@ export class ComboAnalyzer<T> {
     T4 extends T,
     T5 extends T
   >(
-    allOptions: [T1[], T2[], T3[], T4[], T5[]],
-    isValidCombo?: (options: [T1, T2, T3, T4, T5]) => boolean
-  ): [T1, T2, T3, T4, T5][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[],
+      readonly T5[]
+    ],
+    isValidCombo?: (options: readonly [T1, T2, T3, T4, T5]) => boolean
+  ): readonly [T1, T2, T3, T4, T5][];
   getPossibleCombos<T1 extends T, T2 extends T, T3 extends T, T4 extends T>(
-    allOptions: [T1[], T2[], T3[], T4[]],
-    isValidCombo?: (options: [T1, T2, T3, T4]) => boolean
-  ): [T1, T2, T3, T4][];
+    allOptions: readonly [
+      readonly T1[],
+      readonly T2[],
+      readonly T3[],
+      readonly T4[]
+    ],
+    isValidCombo?: (options: readonly [T1, T2, T3, T4]) => boolean
+  ): readonly [T1, T2, T3, T4][];
   getPossibleCombos<T1 extends T, T2 extends T, T3 extends T>(
-    allOptions: [T1[], T2[], T3[]],
-    isValidCombo?: (options: [T1, T2, T3]) => boolean
-  ): [T1, T2, T3][];
+    allOptions: readonly [readonly T1[], readonly T2[], readonly T3[]],
+    isValidCombo?: (options: readonly [T1, T2, T3]) => boolean
+  ): readonly [T1, T2, T3][];
   getPossibleCombos<T1 extends T, T2 extends T>(
-    allOptions: [T1[], T2[]],
-    isValidCombo?: (options: [T1, T2]) => boolean
-  ): [T1, T2][];
+    allOptions: readonly [readonly T1[], readonly T2[]],
+    isValidCombo?: (options: readonly [T1, T2]) => boolean
+  ): readonly [T1, T2][];
   getPossibleCombos<T1 extends T>(
-    allOptions: [T1[]],
-    isValidCombo?: (options: [T1]) => boolean
-  ): [T1][];
+    allOptions: readonly [readonly T1[]],
+    isValidCombo?: (options: readonly [T1]) => boolean
+  ): readonly (readonly [T1])[];
   getPossibleCombos(
-    allOptions: T[][],
-    isValidCombo?: (options: T[]) => boolean
-  ): T[][];
-  getPossibleCombos(allOptions: T[][], isValidCombo?: unknown): T[][] {
+    allOptions: readonly (readonly T[])[],
+    isValidCombo?: (options: readonly T[]) => boolean
+  ): readonly (readonly T[])[];
+  getPossibleCombos(
+    allOptions: readonly (readonly T[])[],
+    isValidCombo?: unknown
+  ): readonly (readonly T[])[] {
     return this._getPossibleCombos(
       allOptions,
-      isValidCombo as (options: T[]) => boolean
+      isValidCombo as (options: readonly T[]) => boolean
     );
   }
 
   private _getPossibleCombos(
-    allOptionsLibrary: T[][],
-    isValidCombo: (options: T[]) => boolean = () => true,
+    allOptionsLibrary: readonly (readonly T[])[],
+    isValidCombo: (options: readonly T[]) => boolean = () => true,
     possibleCombos: T[][] = [],
     allOptionsIndex = 0,
     currentCombo: T[] = []
-  ): T[][] {
+  ): readonly T[][] {
     if (allOptionsIndex === allOptionsLibrary.length) {
       if (isValidCombo(currentCombo)) {
         possibleCombos.push([...currentCombo]);

--- a/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.spec.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.spec.ts
@@ -1,0 +1,42 @@
+import { Options } from '../game/options';
+import { getPossibleCombos } from './get-possible-combos';
+
+describe('getPossibleCombos', () => {
+  it('returns no combos when passed empty options', () => {
+    expect(
+      getPossibleCombos({
+        expansions: [],
+        maps: [],
+        adversaryLevels: [],
+        scenarios: [],
+        difficultyRange: [0, 0],
+      })
+    ).toEqual([]);
+  });
+
+  it('returns posible combos when passed options', () => {
+    expect(
+      getPossibleCombos({
+        expansions: ['Jagged Earth', 'Promo Pack 2'],
+        maps: Options.allMaps,
+        adversaryLevels: [
+          { id: 'bp-0', name: 'Level 0', difficulty: 1 },
+          { id: 'bp-1', name: 'Level 1', difficulty: 2 },
+        ],
+        scenarios: [
+          {
+            name: 'Elemental Invocation',
+            difficulty: 0,
+            expansion: 'Jagged Earth',
+          },
+          {
+            name: 'Varied Terrains',
+            difficulty: 2,
+            expansion: 'Promo Pack 2',
+          },
+        ],
+        difficultyRange: [0, 3],
+      })
+    ).toHaveLength(5);
+  });
+});

--- a/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
@@ -16,14 +16,15 @@ export function getPossibleCombos({
   maps,
   adversaries,
   scenarios,
-  difficultyRange: [min, max],
+  difficultyRange,
 }: {
   expansions: ExpansionName[];
   maps: Map[];
   adversaries: AdversaryLevel[];
   scenarios: Scenario[];
-  difficultyRange: [Difficulty, Difficulty];
+  difficultyRange: Difficulty[];
 }) {
+  const [min, max] = difficultyRange;
   return comboAnalyzer.getPossibleCombos(
     [maps, adversaries, scenarios],
     (options) => {

--- a/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
@@ -14,19 +14,19 @@ const comboAnalyzer = new ComboAnalyzer<
 export function getPossibleCombos({
   expansions,
   maps,
-  adversaries,
+  adversaryLevels,
   scenarios,
   difficultyRange,
 }: {
   expansions: readonly ExpansionName[];
   maps: readonly Map[];
-  adversaries: readonly AdversaryLevel[];
+  adversaryLevels: readonly AdversaryLevel[];
   scenarios: readonly Scenario[];
   difficultyRange: readonly Difficulty[];
 }) {
   const [min, max] = difficultyRange;
   return comboAnalyzer.getPossibleCombos(
-    [maps, adversaries, scenarios],
+    [maps, adversaryLevels, scenarios],
     (options) => {
       const difficulty = options.reduce(
         (accum, option) =>

--- a/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
@@ -18,11 +18,11 @@ export function getPossibleCombos({
   scenarios,
   difficultyRange,
 }: {
-  expansions: ExpansionName[];
-  maps: Map[];
-  adversaries: AdversaryLevel[];
-  scenarios: Scenario[];
-  difficultyRange: Difficulty[];
+  expansions: readonly ExpansionName[];
+  maps: readonly Map[];
+  adversaries: readonly AdversaryLevel[];
+  scenarios: readonly Scenario[];
+  difficultyRange: readonly Difficulty[];
 }) {
   const [min, max] = difficultyRange;
   return comboAnalyzer.getPossibleCombos(

--- a/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-possible-combos.ts
@@ -1,0 +1,38 @@
+import { AdversaryLevel, AdversaryLevelName } from '../game/adversaries';
+import { Difficulty } from '../game/difficulty';
+import { Map, MapName } from '../game/maps';
+import { DifficultyOption } from '../game/option';
+import { Options } from '../game/options';
+import { Scenario, ScenarioName } from '../game/scenarios';
+import { ExpansionName } from '../game/expansions';
+import { ComboAnalyzer } from './combo-analyzer';
+
+const comboAnalyzer = new ComboAnalyzer<
+  DifficultyOption<MapName | AdversaryLevelName | ScenarioName>
+>();
+
+export function getPossibleCombos({
+  expansions,
+  maps,
+  adversaries,
+  scenarios,
+  difficultyRange: [min, max],
+}: {
+  expansions: ExpansionName[];
+  maps: Map[];
+  adversaries: AdversaryLevel[];
+  scenarios: Scenario[];
+  difficultyRange: [Difficulty, Difficulty];
+}) {
+  return comboAnalyzer.getPossibleCombos(
+    [maps, adversaries, scenarios],
+    (options) => {
+      const difficulty = options.reduce(
+        (accum, option) =>
+          accum + Options.getDifficulty(option.difficulty, expansions),
+        0
+      );
+      return difficulty >= min && difficulty <= max;
+    }
+  );
+}

--- a/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
@@ -15,9 +15,9 @@ export function getValidCombos(
     adversaryLevelIds,
     difficultyRange,
   } = config;
-  const maps = Options.allMaps.filter((map) => mapNames.includes(map.name));
-  const scenarios = Options.allScenarios.filter((scenario) =>
-    scenarioNames.includes(scenario.name)
+  const maps = Options.allMaps.filter(({ name }) => mapNames.includes(name));
+  const scenarios = Options.allScenarios.filter(({ name }) =>
+    scenarioNames.includes(name)
   );
   const adversaries = Options.allAdversaries.reduce<AdversaryLevel[]>(
     (levels, adversary) => {

--- a/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
@@ -1,14 +1,9 @@
-import { Map, MapName } from '../game/maps';
-import { Scenario, ScenarioName } from '../game/scenarios';
-import { AdversaryLevel, AdversaryLevelName } from '../game/adversaries';
-import { ComboAnalyzer } from './combo-analyzer';
-import type { Config } from './config.interface';
-import { DifficultyOption } from '../game/option';
+import { Map } from '../game/maps';
+import { Scenario } from '../game/scenarios';
+import { AdversaryLevel } from '../game/adversaries';
 import { Options } from '../game/options';
-
-const comboAnalyzer = new ComboAnalyzer<
-  DifficultyOption<MapName | AdversaryLevelName | ScenarioName>
->();
+import type { Config } from './config.interface';
+import { getPossibleCombos } from './get-possible-combos';
 
 export function getValidCombos(
   config: Config
@@ -29,16 +24,15 @@ export function getValidCombos(
     []
   );
 
-  return comboAnalyzer.getPossibleCombos(
-    [maps, adversaries, scenarios],
-    (options) => {
-      const [min, max] = config.difficultyRange;
-      const difficulty = options.reduce(
-        (accum, option) =>
-          accum + Options.getDifficulty(option.difficulty, config.expansions),
-        0
-      );
-      return difficulty >= min && difficulty <= max;
-    }
-  );
+  // Create mutable copies to satisfy ComboAnalyzer param types
+  const expansions = config.expansions.slice();
+  const difficultyRange = config.difficultyRange.slice();
+
+  return getPossibleCombos({
+    expansions,
+    maps,
+    adversaries,
+    scenarios,
+    difficultyRange,
+  });
 }

--- a/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
@@ -19,13 +19,13 @@ export function getValidCombos(
   const scenarios = Options.allScenarios.filter(({ name }) =>
     scenarioNames.includes(name)
   );
-  const adversaries = Options.allAdversaries.reduce<AdversaryLevel[]>(
-    (levels, adversary) => {
+  const adversaryLevels = Options.allAdversaries.reduce<AdversaryLevel[]>(
+    (accum, adversary) => {
       const adversaryLevels = adversary.levels.filter((level) =>
         adversaryLevelIds.includes(level.id)
       );
-      levels.push(...adversaryLevels);
-      return levels;
+      accum.push(...adversaryLevels);
+      return accum;
     },
     []
   );
@@ -33,7 +33,7 @@ export function getValidCombos(
   return getPossibleCombos({
     expansions,
     maps,
-    adversaries,
+    adversaryLevels,
     scenarios,
     difficultyRange,
   });

--- a/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
@@ -7,8 +7,14 @@ import { getPossibleCombos } from './get-possible-combos';
 
 export function getValidCombos(
   config: Config
-): [Map, AdversaryLevel, Scenario][] {
-  const { mapNames, scenarioNames, adversaryLevelIds } = config;
+): readonly [Map, AdversaryLevel, Scenario][] {
+  const {
+    expansions,
+    mapNames,
+    scenarioNames,
+    adversaryLevelIds,
+    difficultyRange,
+  } = config;
   const maps = Options.allMaps.filter((map) => mapNames.includes(map.name));
   const scenarios = Options.allScenarios.filter((scenario) =>
     scenarioNames.includes(scenario.name)
@@ -23,10 +29,6 @@ export function getValidCombos(
     },
     []
   );
-
-  // Create mutable copies to satisfy ComboAnalyzer param types
-  const expansions = config.expansions.slice();
-  const difficultyRange = config.difficultyRange.slice();
 
   return getPossibleCombos({
     expansions,

--- a/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
+++ b/libs/spirit-islander/shared/util/src/lib/app/get-valid-combos.ts
@@ -20,9 +20,9 @@ export function getValidCombos(
     scenarioNames.includes(name)
   );
   const adversaryLevels = Options.allAdversaries.reduce<AdversaryLevel[]>(
-    (accum, adversary) => {
-      const adversaryLevels = adversary.levels.filter((level) =>
-        adversaryLevelIds.includes(level.id)
+    (accum, { levels }) => {
+      const adversaryLevels = levels.filter(({ id }) =>
+        adversaryLevelIds.includes(id)
       );
       accum.push(...adversaryLevels);
       return accum;


### PR DESCRIPTION
1. Type all `ComboAnalyzer` arrays as `readonly`
2. Create wrapper function `getPossibleCombos` for specific use in SI in order to allow future relocation of `getValidCombos`