### PR TITLE
Custom function for retrieving spirits by expansion

### DIFF
--- a/libs/spirit-islander/config/feature/src/lib/config-form/models.ts
+++ b/libs/spirit-islander/config/feature/src/lib/config-form/models.ts
@@ -13,6 +13,7 @@ import {
   getAdversaryLevelIds,
   getOptionsByExpansion,
   getNames,
+  getSpiritsByExpansion,
 } from '@atocha/spirit-islander/shared/util';
 
 export class Models {
@@ -66,7 +67,7 @@ export class Models {
     target: 'Expansions' | Expansion
   ): Models {
     this._spiritNames = this._updateModel(
-      (expansions) => getNames(getOptionsByExpansion(SPIRITS, expansions)),
+      (expansions) => getNames(getSpiritsByExpansion(SPIRITS, expansions)),
       this._spiritNames,
       expansions,
       target

--- a/libs/spirit-islander/config/feature/src/lib/config-form/root.ts
+++ b/libs/spirit-islander/config/feature/src/lib/config-form/root.ts
@@ -17,6 +17,7 @@ import {
   SpiritFamilyName,
   getDifficulty,
   getOptionsByExpansion,
+  getSpiritsByExpansion,
 } from '@atocha/spirit-islander/shared/util';
 
 export interface Node<T> {
@@ -64,7 +65,7 @@ export class Root {
   update(expansions: readonly Expansion[]) {
     this._spirits = this._createRoot({
       root: 'Spirits',
-      items: getOptionsByExpansion(SPIRITS, expansions),
+      items: getSpiritsByExpansion(SPIRITS, expansions),
       getId: ({ name }) => name,
       getDisplay: ({ expansion, aspectOf }) => {
         const display: {

--- a/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.spec.ts
+++ b/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.spec.ts
@@ -1,17 +1,32 @@
 import { getSpiritsByExpansion } from './get-spirits-by-expansion';
 
 describe('getSpiritsByExpansion', () => {
+  it('returns spirits from base expansions no matter what', () => {
+    expect(
+      getSpiritsByExpansion(
+        [
+          { name: 'Finder of Paths Unseen', expansion: 'Promo Pack 2' },
+          { name: "Ocean's Hungry Grasp" },
+          { name: 'Thunderspeaker' },
+        ],
+        []
+      )
+    ).toEqual([{ name: "Ocean's Hungry Grasp" }, { name: 'Thunderspeaker' }]);
+  });
+
   it('returns spirits from certain expansions', () => {
     expect(
       getSpiritsByExpansion(
         [
           { name: 'A Spread of Rampant Green', expansion: 'Branch & Claw' },
+          { name: 'Bringer of Dreams and Nightmares' },
           { name: "Stone's Unyielding Defiance", expansion: 'Jagged Earth' },
         ],
         ['Branch & Claw']
       )
     ).toEqual([
       { name: 'A Spread of Rampant Green', expansion: 'Branch & Claw' },
+      { name: 'Bringer of Dreams and Nightmares' },
     ]);
   });
 });

--- a/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.spec.ts
+++ b/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.spec.ts
@@ -1,0 +1,17 @@
+import { getSpiritsByExpansion } from './get-spirits-by-expansion';
+
+describe('getSpiritsByExpansion', () => {
+  it('returns spirits from certain expansions', () => {
+    expect(
+      getSpiritsByExpansion(
+        [
+          { name: 'A Spread of Rampant Green', expansion: 'Branch & Claw' },
+          { name: "Stone's Unyielding Defiance", expansion: 'Jagged Earth' },
+        ],
+        ['Branch & Claw']
+      )
+    ).toEqual([
+      { name: 'A Spread of Rampant Green', expansion: 'Branch & Claw' },
+    ]);
+  });
+});

--- a/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.ts
+++ b/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.ts
@@ -1,9 +1,9 @@
-import { Expansion, Spirit } from '../types';
+import { Expansion, Spirit, SpiritName } from '../types';
 import { getOptionsByExpansion } from './get-options-by-expansion';
 
 export function getSpiritsByExpansion(
   spirits: readonly Spirit[],
   expansions: readonly Expansion[]
 ): readonly Spirit[] {
-  return getOptionsByExpansion(spirits, expansions);
+  return getOptionsByExpansion<SpiritName, Spirit>(spirits, expansions);
 }

--- a/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.ts
+++ b/libs/spirit-islander/shared/util/src/lib/functions/get-spirits-by-expansion.ts
@@ -1,0 +1,9 @@
+import { Expansion, Spirit } from '../types';
+import { getOptionsByExpansion } from './get-options-by-expansion';
+
+export function getSpiritsByExpansion(
+  spirits: readonly Spirit[],
+  expansions: readonly Expansion[]
+): readonly Spirit[] {
+  return getOptionsByExpansion(spirits, expansions);
+}

--- a/libs/spirit-islander/shared/util/src/lib/functions/index.ts
+++ b/libs/spirit-islander/shared/util/src/lib/functions/index.ts
@@ -3,4 +3,5 @@ export * from './get-difficulty';
 export * from './get-names';
 export * from './get-options-by-expansion';
 export * from './get-options-by-name';
+export * from './get-spirits-by-expansion';
 export * from './group-spirits';


### PR DESCRIPTION
Writes and implements new function `getSpiritsByExpansion` that currently wraps `getOptionsByExpansion`. In the following task, this function's logic can be modified to exclude aspects whose spirits were filtered from the results.

Resolves #466 