### PR TITLE
Service logic improvements

### DIFF
--- a/libs/spirit-islander/config/feature/src/lib/config.component.ts
+++ b/libs/spirit-islander/config/feature/src/lib/config.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { first, map } from 'rxjs';
+import { first } from 'rxjs';
 
 import {
   RouterService,
@@ -23,10 +23,7 @@ import { ConfigFormComponent } from './config-form/config-form.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConfigComponent {
-  config$ = this._stateService.state$.pipe(
-    first(),
-    map(({ config }) => config)
-  );
+  config$ = this._stateService.config$.pipe(first());
 
   constructor(
     private _routerService: RouterService,

--- a/libs/spirit-islander/game-setup/feature/src/lib/game-setup.component.ts
+++ b/libs/spirit-islander/game-setup/feature/src/lib/game-setup.component.ts
@@ -45,6 +45,6 @@ export class GameSetupComponent implements OnInit {
   }
 
   onRegenerate(): void {
-    this._stateService.refreshGameSetup();
+    this._stateService.updateGameSetup();
   }
 }

--- a/libs/spirit-islander/game-setup/feature/src/lib/game-setup.component.ts
+++ b/libs/spirit-islander/game-setup/feature/src/lib/game-setup.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { first, map } from 'rxjs';
+import { first } from 'rxjs';
 
 import {
   RouterService,
@@ -24,9 +24,7 @@ import { GameSetupOutputComponent } from './game-setup-output/game-setup-output.
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GameSetupComponent implements OnInit {
-  gameSetup$ = this._stateService.state$.pipe(
-    map(({ gameSetup }) => gameSetup)
-  );
+  gameSetup$ = this._stateService.gameSetup$;
 
   constructor(
     private _route: ActivatedRoute,

--- a/libs/spirit-islander/settings/feature/src/settings.component.ts
+++ b/libs/spirit-islander/settings/feature/src/settings.component.ts
@@ -5,7 +5,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { map } from 'rxjs';
 
 import { ButtonComponent, CheckboxComponent } from '@atocha/core/ui';
 import { Settings } from '@atocha/spirit-islander/settings/util';
@@ -74,7 +73,7 @@ import {
   encapsulation: ViewEncapsulation.None,
 })
 export class SettingsComponent {
-  settings$ = this._stateService.state$.pipe(map(({ settings }) => settings));
+  settings$ = this._stateService.settings$;
 
   constructor(private _stateService: StateService) {}
 

--- a/libs/spirit-islander/shared/data-access/src/lib/router.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/router.service.ts
@@ -11,9 +11,7 @@ import { StateService } from './state.service';
   providedIn: 'root',
 })
 export class RouterService {
-  configParams$ = this._stateService.state$.pipe(
-    map(({ config }) => mapConfigToParams(config))
-  );
+  configParams$ = this._stateService.config$.pipe(map(mapConfigToParams));
 
   constructor(private _stateService: StateService, private _router: Router) {}
 

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -36,7 +36,7 @@ export class StateService {
 
   private _state: State<AppState>;
   private _state$: Observable<AppState>;
-  private readonly _oldConfigKey = 'CONFIG_NEW';
+  private readonly _legacyConfigKey = 'CONFIG_NEW';
   private readonly _configKey = 'CONFIG';
   private readonly _settingsKey = 'SETTINGS';
 
@@ -89,12 +89,14 @@ export class StateService {
   }
 
   private _getConfig(): Config {
-    const oldConfig = this._localStorageService.getItem(this._oldConfigKey);
+    const legacyConfig = this._localStorageService.getItem(
+      this._legacyConfigKey
+    );
     const config =
-      oldConfig || this._localStorageService.getItem(this._configKey);
+      legacyConfig || this._localStorageService.getItem(this._configKey);
 
-    if (oldConfig) {
-      this._localStorageService.removeItem(this._oldConfigKey);
+    if (legacyConfig) {
+      this._localStorageService.removeItem(this._legacyConfigKey);
     }
 
     return config

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -4,19 +4,19 @@ import { Observable, first, map, tap } from 'rxjs';
 import { LocalStorageService, State } from '@atocha/core/data-access';
 import { Config } from '@atocha/spirit-islander/config/util';
 import {
-  GameSetup,
   createGameSetup,
+  GameSetup,
 } from '@atocha/spirit-islander/game-setup/util';
 import { Settings } from '@atocha/spirit-islander/settings/util';
 import {
-  getExpansions,
-  getNames,
-  getSpirits,
-  getMaps,
-  getBoards,
-  getScenarios,
-  getAdversaryLevelIds,
   getAdversaries,
+  getAdversaryLevelIds,
+  getBoards,
+  getExpansions,
+  getMaps,
+  getNames,
+  getScenarios,
+  getSpirits,
 } from '@atocha/spirit-islander/shared/util';
 import { migrateConfig } from './internal/app-migration';
 

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { first, tap } from 'rxjs';
+import { first, map, tap } from 'rxjs';
 
 import { LocalStorageService, State } from '@atocha/core/data-access';
 import { Config } from '@atocha/spirit-islander/config/util';
@@ -41,12 +41,16 @@ export class StateService {
     settings: this._settings,
   });
 
-  state$ = this._state.get().pipe(
+  private _state$ = this._state.get().pipe(
     tap(({ config, settings }) => {
       this._setConfig(config);
       this._setSettings(settings);
     })
   );
+
+  config$ = this._state$.pipe(map(({ config }) => config));
+  gameSetup$ = this._state$.pipe(map(({ gameSetup }) => gameSetup));
+  settings$ = this._state$.pipe(map(({ settings }) => settings));
 
   constructor(private _localStorageService: LocalStorageService) {}
 

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -113,13 +113,13 @@ export class StateService {
         };
   }
 
+  private _setConfig(config: Config): void {
+    this._localStorageService.setItem(this._configKey, JSON.stringify(config));
+  }
+
   private _getSettings(): Settings {
     const settings = this._localStorageService.getItem(this._settingsKey);
     return settings ? JSON.parse(settings) : { randomThematicBoards: false };
-  }
-
-  private _setConfig(config: Config): void {
-    this._localStorageService.setItem(this._configKey, JSON.stringify(config));
   }
 
   private _setSettings(settings: Settings): void {

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -72,7 +72,7 @@ export class StateService {
       });
   }
 
-  refreshGameSetup(): void {
+  updateGameSetup(): void {
     this._state
       .get()
       .pipe(first())

--- a/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
+++ b/libs/spirit-islander/shared/data-access/src/lib/state.service.ts
@@ -72,13 +72,6 @@ export class StateService {
       });
   }
 
-  updateSettings(changes: Partial<Settings>): void {
-    this._state.transformProp('settings', (settings) => ({
-      ...settings,
-      ...changes,
-    }));
-  }
-
   refreshGameSetup(): void {
     this._state
       .get()
@@ -86,6 +79,13 @@ export class StateService {
       .subscribe(({ config, settings }) =>
         this._state.updateProp('gameSetup', createGameSetup(config, settings))
       );
+  }
+
+  updateSettings(changes: Partial<Settings>): void {
+    this._state.transformProp('settings', (settings) => ({
+      ...settings,
+      ...changes,
+    }));
   }
 
   private _getConfig(): Config {


### PR DESCRIPTION
1. Derived, public observables for each slice of `state$`
2. Makes `state$` private to the `StateService`
3. Moves initialization logic to constructor to phase out unnecessary local properties
4. More consistent/sensible method ordering in `StateService`