### PR TITLE
Fixes form validation messages not displaying

### DIFF
--- a/libs/spirit-islander/config/feature/src/lib/config-form/config-form.ts
+++ b/libs/spirit-islander/config/feature/src/lib/config-form/config-form.ts
@@ -17,15 +17,15 @@ export class ConfigForm extends FormGroup<Form<Config>> {
   readonly expansions$ = this.get('expansions')?.valueChanges ?? of([]);
 
   get playersError(): string {
-    return this.errors?.[playersOutnumberTotalBoards.name] ?? '';
+    return this.errors?.['playersOutnumberTotalBoards'] ?? '';
   }
 
   get difficultyError(): string {
-    return this.errors?.[invalidDifficultyRange.name] ?? '';
+    return this.errors?.['invalidDifficultyRange'] ?? '';
   }
 
   get spiritsError(): string {
-    return this.errors?.[playersOutnumberSpirits.name] ?? '';
+    return this.errors?.['playersOutnumberSpirits'] ?? '';
   }
 
   get mapsError(): string {
@@ -33,7 +33,7 @@ export class ConfigForm extends FormGroup<Form<Config>> {
   }
 
   get boardsError(): string {
-    return this.errors?.[playersOutnumberSelectedBoards.name] ?? '';
+    return this.errors?.['playersOutnumberSelectedBoards'] ?? '';
   }
 
   get scenariosError(): string {


### PR DESCRIPTION
The validation messages were showing up fine locally, but not in prod. Updating the errors object lookup to access the hard-coded property name rather than the `.name` property on the function fixes it. Angular probably minifies the function names for its production build step, which would explain the discrepancy in environments.