### PR TITLE
Paves the way for Angular 17

### DIFF
--- a/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-card/quiz-card.component.ts
+++ b/libs/globetrotter/feature-learn/src/lib/quiz/quiz-cards/quiz-card/quiz-card.component.ts
@@ -18,7 +18,7 @@ import {
   FlipCardGuess,
   FlipCardSide,
 } from '@atocha/globetrotter/ui';
-import { Country, Duration, QuizType } from '@atocha/globetrotter/util';
+import { Country, DURATION, QuizType } from '@atocha/globetrotter/util';
 
 type CardTemplate = Record<FlipCardSide, TemplateRef<unknown> | undefined>;
 
@@ -86,7 +86,7 @@ export class QuizCardComponent implements OnInit {
     // After flip animation is complete, the card is flipped back over and the guess is reset
     else if (triggerName === 'guess') {
       if (toState === 'correct' || toState === 'incorrect') {
-        await wait(Duration.cardFlipDisplay);
+        await wait(DURATION.cardFlipDisplay);
         this.guess = 'none';
         this.flipCardComponent?.flip();
         this._changeDetectorRef.markForCheck();
@@ -105,7 +105,7 @@ export class QuizCardComponent implements OnInit {
   }
 
   private async _updateQuiz() {
-    await wait(Duration.quizUpdateDelay);
+    await wait(DURATION.quizUpdateDelay);
     this.guessed.emit(this.isCurrentCountry);
     this.flipped.emit(false);
     this._processingFlip = false;

--- a/libs/globetrotter/ui/src/lib/animations.ts
+++ b/libs/globetrotter/ui/src/lib/animations.ts
@@ -11,7 +11,7 @@ import {
   animateChild,
 } from '@angular/animations';
 
-import { Duration } from '@atocha/globetrotter/util';
+import { DURATION } from '@atocha/globetrotter/util';
 
 const fadeIn = animation([
   style({ opacity: '0' }),
@@ -22,7 +22,7 @@ export const fadeInAnimation = trigger('fadeIn', [
   transition(':enter', [
     useAnimation(fadeIn, {
       params: {
-        timing: Duration.fadeIn,
+        timing: DURATION.fadeIn,
         delay: 0,
       },
     }),
@@ -33,8 +33,8 @@ export const fadeInWithFixedSlideablePanelDelayAnimation = trigger('fadeIn', [
   transition(':enter', [
     useAnimation(fadeIn, {
       params: {
-        timing: Duration.fadeIn,
-        delay: Duration.position,
+        timing: DURATION.fadeIn,
+        delay: DURATION.position,
       },
     }),
   ]),
@@ -53,7 +53,7 @@ export const visibilityAnimation = trigger('visibility', [
       opacity: 1,
     })
   ),
-  transition('* => *', animate(`${Duration.fadeIn}ms ease-in-out`)),
+  transition('* => *', animate(`${DURATION.fadeIn}ms ease-in-out`)),
 ]);
 
 export const flipAnimation = trigger('flip', [
@@ -69,8 +69,8 @@ export const flipAnimation = trigger('flip', [
       transform: 'rotateY(180deg)',
     })
   ),
-  transition('front => back', animate(`${Duration.cardAnimation}ms ease-in`)),
-  transition('back => front', animate(`${Duration.cardAnimation}ms ease-out`)),
+  transition('front => back', animate(`${DURATION.cardAnimation}ms ease-in`)),
+  transition('back => front', animate(`${DURATION.cardAnimation}ms ease-out`)),
 ]);
 
 export const disabledAnimation = trigger('disabled', [
@@ -80,7 +80,7 @@ export const disabledAnimation = trigger('disabled', [
       filter: 'grayscale(100%)',
     })
   ),
-  transition('* => disabled', animate(`${Duration.cardAnimation}ms ease-in`)),
+  transition('* => disabled', animate(`${DURATION.cardAnimation}ms ease-in`)),
 ]);
 
 export const guessAnimation = trigger('guess', [
@@ -105,7 +105,7 @@ export const guessAnimation = trigger('guess', [
       padding: '0',
     })
   ),
-  transition('* => *', animate(`${Duration.cardAnimation}ms ease-in`)),
+  transition('* => *', animate(`${DURATION.cardAnimation}ms ease-in`)),
 ]);
 
 export const positionAnimation = trigger('position', [
@@ -133,11 +133,11 @@ export const positionAnimation = trigger('position', [
       transform: 'translateX(100%)',
     })
   ),
-  transition('* => *', animate(`${Duration.position}ms ease-in-out`)),
+  transition('* => *', animate(`${DURATION.position}ms ease-in-out`)),
 ]);
 
 export const staggerAnimation = trigger('stagger', [
   transition(':enter', [
-    query(':enter', stagger(`${Duration.stagger}ms`, [animateChild()])),
+    query(':enter', stagger(`${DURATION.stagger}ms`, [animateChild()])),
   ]),
 ]);

--- a/libs/globetrotter/util/src/index.ts
+++ b/libs/globetrotter/util/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/domain/subregion.interface';
 export * from './lib/domain/summary.interface';
 
 export * from './lib/duration.enum';
+export * from './lib/duration';
 export * from './lib/quiz-type.enum';
 export * from './lib/route.enum';
 export * from './lib/selection.interface';

--- a/libs/globetrotter/util/src/index.ts
+++ b/libs/globetrotter/util/src/index.ts
@@ -9,7 +9,6 @@ export * from './lib/domain/region.interface';
 export * from './lib/domain/subregion.interface';
 export * from './lib/domain/summary.interface';
 
-export * from './lib/duration.enum';
 export * from './lib/duration';
 export * from './lib/quiz-type.enum';
 export * from './lib/route.enum';

--- a/libs/globetrotter/util/src/lib/duration.enum.ts
+++ b/libs/globetrotter/util/src/lib/duration.enum.ts
@@ -1,8 +1,0 @@
-export enum Duration {
-  cardAnimation = 300,
-  cardFlipDisplay = 1000,
-  quizUpdateDelay = 100,
-  fadeIn = 300,
-  position = 500,
-  stagger = 100,
-}

--- a/libs/globetrotter/util/src/lib/duration.ts
+++ b/libs/globetrotter/util/src/lib/duration.ts
@@ -1,0 +1,8 @@
+export const DURATION: Readonly<Record<string, number>> = {
+  cardAnimation: 300,
+  cardFlipDisplay: 1000,
+  quizUpdateDelay: 100,
+  fadeIn: 300,
+  position: 500,
+  stagger: 100,
+};

--- a/libs/globetrotter/util/src/lib/duration.ts
+++ b/libs/globetrotter/util/src/lib/duration.ts
@@ -1,8 +1,8 @@
-export const DURATION: Readonly<Record<string, number>> = {
+export const DURATION = {
   cardAnimation: 300,
   cardFlipDisplay: 1000,
   quizUpdateDelay: 100,
   fadeIn: 300,
   position: 500,
   stagger: 100,
-};
+} as const;

--- a/libs/sandbox/ui/src/lib/click-outside/click-outside.directive.spec.ts
+++ b/libs/sandbox/ui/src/lib/click-outside/click-outside.directive.spec.ts
@@ -37,7 +37,7 @@ describe('ClickOutsideDirective', () => {
     jest
       .spyOn(window, 'requestAnimationFrame')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation((cb) => cb(0) as any);
+      .mockImplementation((cb: any) => cb(0) as any);
   });
 
   it('should create', () => {


### PR DESCRIPTION
Handles a couple of issues that arose in the pipeline of [this PR](https://github.com/johnnycopes/atocha/pull/488) that can be isolated:

1. Replaces `duration.enum` file with `duration.ts`, containing a readonly `as const` declaration instead (this allows duplicate values for different keys, which enums apparently no longer do)
2. Explicitly types test param in `click-outside.directive.spec.ts`