### PR TITLE
More efficient data fetching

### DIFF
--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
@@ -42,20 +42,21 @@ export class DishService implements IEntityService<Dish, EditableDishData> {
     );
   }
 
-  getAll(): Observable<Dish[]> {
+  getAll(
+    { tags }: { tags?: boolean } = {
+      tags: false,
+    }
+  ): Observable<Dish[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
             this._dishDtoService.getAll(uid),
-            this._ingredientService.getAll(),
-            this._tagService.getAll(),
+            tags ? this._tagService.getAll() : of([]),
           ]).pipe(
-            map(([dishDtos, ingredients, tags]) =>
-              dishDtos.map((dishDto) =>
-                mapDishDtoToDish(dishDto, ingredients, tags)
-              )
+            map(([dishDtos, tags]) =>
+              dishDtos.map((dishDto) => mapDishDtoToDish(dishDto, [], tags))
             )
           );
         }

--- a/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/dish.service.ts
@@ -30,8 +30,8 @@ export class DishService implements IEntityService<Dish, EditableDishData> {
   getOne(id: string): Observable<Dish | undefined> {
     return combineLatest([
       this._dishDtoService.getOne(id),
-      this._ingredientService.getMany(),
-      this._tagService.getMany(),
+      this._ingredientService.getAll(),
+      this._tagService.getAll(),
     ]).pipe(
       map(([dishDto, ingredients, tags]) => {
         if (!dishDto) {
@@ -42,15 +42,15 @@ export class DishService implements IEntityService<Dish, EditableDishData> {
     );
   }
 
-  getMany(): Observable<Dish[]> {
+  getAll(): Observable<Dish[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._dishDtoService.getMany(uid),
-            this._ingredientService.getMany(),
-            this._tagService.getMany(),
+            this._dishDtoService.getAll(uid),
+            this._ingredientService.getAll(),
+            this._tagService.getAll(),
           ]).pipe(
             map(([dishDtos, ingredients, tags]) =>
               dishDtos.map((dishDto) =>

--- a/libs/menu-matriarch/dishes/data-access/src/lib/internal/dish-dto.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/internal/dish-dto.service.ts
@@ -44,7 +44,7 @@ export class DishDtoService implements IDtoService<Dish, DishDto> {
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<DishDto[]> {
+  getAll(uid: string): Observable<DishDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/dishes/feature/src/lib/dish-edit/dish-edit.component.ts
+++ b/libs/menu-matriarch/dishes/feature/src/lib/dish-edit/dish-edit.component.ts
@@ -36,8 +36,8 @@ export class DishEditComponent {
     : of(undefined);
   dish$: Observable<DishConfig> = combineLatest([
     this._dish$,
-    this._ingredientService.getMany(),
-    this._tagService.getMany(),
+    this._ingredientService.getAll(),
+    this._tagService.getAll(),
   ]).pipe(
     map(([dish, ingredients, tags]) => ({
       name: dish?.name ?? '',

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient-type.service.ts
@@ -27,7 +27,7 @@ export class IngredientTypeService
   getOne(id: string): Observable<IngredientType | undefined> {
     return combineLatest([
       this._ingredientTypeDtoService.getOne(id),
-      this._ingredientService.getMany(),
+      this._ingredientService.getAll(),
     ]).pipe(
       map(([ingredientTypeDto, ingredients]) => {
         if (!ingredientTypeDto) {
@@ -41,14 +41,14 @@ export class IngredientTypeService
     );
   }
 
-  getMany(): Observable<IngredientType[]> {
+  getAll(): Observable<IngredientType[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._ingredientTypeDtoService.getMany(uid),
-            this._ingredientService.getMany(),
+            this._ingredientTypeDtoService.getAll(uid),
+            this._ingredientService.getAll(),
           ]).pipe(
             map(([dishDtos, ingredients]) =>
               dishDtos.map((dishDto) =>

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/ingredient.service.ts
@@ -25,12 +25,12 @@ export class IngredientService
     return this._ingredientDtoService.getOne(id);
   }
 
-  getMany(): Observable<Ingredient[]> {
+  getAll(): Observable<Ingredient[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._ingredientDtoService.getMany(uid);
+          return this._ingredientDtoService.getAll(uid);
         }
         return of([]);
       })

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-dto.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-dto.service.ts
@@ -36,7 +36,7 @@ export class IngredientDtoService
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<IngredientDto[]> {
+  getAll(uid: string): Observable<IngredientDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-type-dto.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-type-dto.service.ts
@@ -33,7 +33,7 @@ export class IngredientTypeDtoService
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<IngredientTypeDto[]> {
+  getAll(uid: string): Observable<IngredientTypeDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/ingredients/feature/src/lib/ingredients.component.ts
+++ b/libs/menu-matriarch/ingredients/feature/src/lib/ingredients.component.ts
@@ -40,7 +40,7 @@ export class IngredientsComponent {
 
   vm$ = combineLatest([
     this._userService.getPreferences(),
-    this._ingredientTypeService.getMany(),
+    this._ingredientTypeService.getAll(),
     this.addingSubject.asObservable(),
   ]).pipe(
     map(([preferences, ingredientTypes, adding]) => {

--- a/libs/menu-matriarch/meals/data-access/src/lib/internal/meal-dto.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/internal/meal-dto.service.ts
@@ -34,7 +34,7 @@ export class MealDtoService implements IDtoService<Meal, MealDto> {
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<MealDto[]> {
+  getAll(uid: string): Observable<MealDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/meals/data-access/src/lib/meal.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/meal.service.ts
@@ -30,8 +30,8 @@ export class MealService implements IEntityService<Meal, EditableMealData> {
   getOne(id: string): Observable<Meal | undefined> {
     return combineLatest([
       this._mealDtoService.getOne(id),
-      this._dishService.getMany(),
-      this._tagService.getMany(),
+      this._dishService.getAll(),
+      this._tagService.getAll(),
     ]).pipe(
       map(([mealDto, dishes, tags]) => {
         if (!mealDto) {
@@ -42,15 +42,15 @@ export class MealService implements IEntityService<Meal, EditableMealData> {
     );
   }
 
-  getMany(): Observable<Meal[]> {
+  getAll(): Observable<Meal[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._mealDtoService.getMany(uid),
-            this._dishService.getMany(),
-            this._tagService.getMany(),
+            this._mealDtoService.getAll(uid),
+            this._dishService.getAll(),
+            this._tagService.getAll(),
           ]).pipe(
             map(([mealDtos, dishes, tags]) =>
               mealDtos.map((mealDto) =>

--- a/libs/menu-matriarch/meals/feature/src/lib/meal-edit/meal-edit.component.ts
+++ b/libs/menu-matriarch/meals/feature/src/lib/meal-edit/meal-edit.component.ts
@@ -39,8 +39,8 @@ export class MealEditComponent {
 
   meal$: Observable<MealConfig> = combineLatest([
     this._meal$,
-    this._dishService.getMany(),
-    this._tagService.getMany(),
+    this._dishService.getAll(),
+    this._tagService.getAll(),
     this._userService.getPreferences(),
   ]).pipe(
     map(([meal, dishes, tags, preferences]) => ({

--- a/libs/menu-matriarch/menus/data-access/src/lib/internal/menu-dto.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/internal/menu-dto.service.ts
@@ -31,7 +31,7 @@ export class MenuDtoService implements IDtoService<Menu, MenuDto> {
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<MenuDto[]> {
+  getAll(uid: string): Observable<MenuDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/menus/data-access/src/lib/menu.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/menu.service.ts
@@ -28,7 +28,7 @@ export class MenuService implements IEntityService<Menu, EditableMenuData> {
   getOne(id: string): Observable<Menu | undefined> {
     return combineLatest([
       this._menuDtoService.getOne(id),
-      this._dishService.getMany(),
+      this._dishService.getAll(),
       this._userService.getPreferences(),
     ]).pipe(
       map(([menuDto, dishes, preferences]) => {
@@ -40,14 +40,14 @@ export class MenuService implements IEntityService<Menu, EditableMenuData> {
     );
   }
 
-  getMany(): Observable<Menu[]> {
+  getAll(): Observable<Menu[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
           return combineLatest([
-            this._menuDtoService.getMany(uid),
-            this._dishService.getMany(),
+            this._menuDtoService.getAll(uid),
+            this._dishService.getAll(),
             this._userService.getPreferences(),
           ]).pipe(
             map(([menuDtos, dishes, preferences]) => {

--- a/libs/menu-matriarch/menus/feature/src/lib/menus.component.ts
+++ b/libs/menu-matriarch/menus/feature/src/lib/menus.component.ts
@@ -31,7 +31,7 @@ export class MenusComponent {
   addingSubject = new BehaviorSubject<boolean>(false);
 
   vm$ = combineLatest([
-    this._menuService.getMany(),
+    this._menuService.getAll(),
     this._menuService.activeMenuId$,
     this.addingSubject.asObservable(),
   ]).pipe(

--- a/libs/menu-matriarch/shared/data-access-api/src/lib/types/dto-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-api/src/lib/types/dto-service.interface.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 
 export interface IDtoService<TEntity, TDto, TData = Partial<TEntity>> {
   getOne(id: string): Observable<TDto | undefined>;
-  getMany(uid: string): Observable<TDto[]>;
+  getAll(uid: string): Observable<TDto[]>;
   create(uid: string, data: TData): Promise<string>;
   update(item: TEntity, data: TData): Promise<void>;
   delete(item: TEntity): Promise<void>;

--- a/libs/menu-matriarch/shared/data-access-api/src/lib/types/entity-service.interface.ts
+++ b/libs/menu-matriarch/shared/data-access-api/src/lib/types/entity-service.interface.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 
 export interface IEntityService<TEntity, TData = Partial<TEntity>> {
   getOne(id: string): Observable<TEntity | undefined>;
-  getMany(): Observable<TEntity[]>;
+  getAll(): Observable<TEntity[]>;
   create(data: TData): Observable<string | undefined>;
   update(item: TEntity, data: TData): Promise<void>;
   delete(item: TEntity): Promise<void>;

--- a/libs/menu-matriarch/shared/feature/src/lib/dishes-list/dishes-list.component.ts
+++ b/libs/menu-matriarch/shared/feature/src/lib/dishes-list/dishes-list.component.ts
@@ -41,8 +41,8 @@ import { FilterService } from '../filter.service';
 export class DishesListComponent {
   @Output() nameDblClick = new EventEmitter<void>();
   vm$ = combineLatest([
-    this._dishService.getMany(),
-    this._tagService.getMany(),
+    this._dishService.getAll(),
+    this._tagService.getAll(),
     this._filterService.state$,
     this._dishService.activeDishId$,
   ]).pipe(

--- a/libs/menu-matriarch/shared/feature/src/lib/dishes-list/dishes-list.component.ts
+++ b/libs/menu-matriarch/shared/feature/src/lib/dishes-list/dishes-list.component.ts
@@ -41,7 +41,7 @@ import { FilterService } from '../filter.service';
 export class DishesListComponent {
   @Output() nameDblClick = new EventEmitter<void>();
   vm$ = combineLatest([
-    this._dishService.getAll(),
+    this._dishService.getAll({ tags: true }),
     this._tagService.getAll(),
     this._filterService.state$,
     this._dishService.activeDishId$,

--- a/libs/menu-matriarch/shared/feature/src/lib/meals-list/meals-list.component.ts
+++ b/libs/menu-matriarch/shared/feature/src/lib/meals-list/meals-list.component.ts
@@ -31,8 +31,8 @@ import { MealDefContext, MealDefDirective } from './meal-def.directive';
 export class MealsListComponent {
   @Output() nameDblClick = new EventEmitter<void>();
   vm$ = combineLatest([
-    this._mealService.getMany(),
-    this._tagService.getMany(),
+    this._mealService.getAll(),
+    this._tagService.getAll(),
     this._userService.getPreferences(),
     this._filterService.state$,
     this._mealService.activeMealId$,

--- a/libs/menu-matriarch/tags/data-access/src/lib/internal/tag-dto.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/internal/tag-dto.service.ts
@@ -31,7 +31,7 @@ export class TagDtoService implements IDtoService<Tag, TagDto> {
     return this._dtoService.getOne(this._endpoint, id);
   }
 
-  getMany(uid: string): Observable<TagDto[]> {
+  getAll(uid: string): Observable<TagDto[]> {
     return this._dtoService.getMany(this._endpoint, uid);
   }
 

--- a/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/tag.service.ts
@@ -20,12 +20,12 @@ export class TagService implements IEntityService<Tag, EditableTagData> {
     return this._tagDtoService.getOne(id);
   }
 
-  getMany(): Observable<Tag[]> {
+  getAll(): Observable<Tag[]> {
     return this._authService.uid$.pipe(
       first(),
       concatMap((uid) => {
         if (uid) {
-          return this._tagDtoService.getMany(uid);
+          return this._tagDtoService.getAll(uid);
         }
         return of([]);
       })

--- a/libs/menu-matriarch/tags/feature/src/lib/tags.component.ts
+++ b/libs/menu-matriarch/tags/feature/src/lib/tags.component.ts
@@ -25,7 +25,7 @@ import { TagCardComponent } from './tag-card/tag-card.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TagsComponent {
-  tags$ = this._tagService.getMany();
+  tags$ = this._tagService.getAll();
   startAdd$ = new Subject<void>();
   finishAdd$ = new Subject<void>();
   adding$ = merge(


### PR DESCRIPTION
1. Renames `getMany` to `getAll` (this will pave the way for a future `getMany` with signature `<T>(ids: string[]) => Observable<T[]>`
2. Updates DishService `getAll` call to a) never fetch ingredients (wherever all dishes are shown, it's in a summarized list format without ingredients) and b) optionally include tags call (tags are only needed sometimes, like in meal summaries)