### PR TITLE
Renames remaining `getMany` methods to `getAll`

### DIFF
--- a/libs/firebase/data-access/src/lib/dto.service.ts
+++ b/libs/firebase/data-access/src/lib/dto.service.ts
@@ -17,8 +17,8 @@ export class DtoService<T> {
     return this._firestoreService.getOne<T>(endpoint, id);
   }
 
-  getMany(endpoint: string, uid: string): Observable<T[]> {
-    return this._firestoreService.getMany<T>(endpoint, uid);
+  getAll(endpoint: string, uid: string): Observable<T[]> {
+    return this._firestoreService.getAll<T>(endpoint, uid);
   }
 
   async create(endpoint: string, id: string, details: T): Promise<void> {

--- a/libs/firebase/data-access/src/lib/firestore/firestore.service.ts
+++ b/libs/firebase/data-access/src/lib/firestore/firestore.service.ts
@@ -52,7 +52,7 @@ export class FirestoreService {
     );
   }
 
-  getMany<T>(endpoint: string, uid: string): Observable<T[]> {
+  getAll<T>(endpoint: string, uid: string): Observable<T[]> {
     const q = query(
       collection(this._firestore, endpoint) as CollectionReference<T>,
       where('uid', '==', uid),

--- a/libs/menu-matriarch/dishes/data-access/src/lib/internal/dish-dto.service.ts
+++ b/libs/menu-matriarch/dishes/data-access/src/lib/internal/dish-dto.service.ts
@@ -45,7 +45,7 @@ export class DishDtoService implements IDtoService<Dish, DishDto> {
   }
 
   getAll(uid: string): Observable<DishDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(uid: string, dish: EditableDishData): Promise<string> {

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-dto.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-dto.service.ts
@@ -37,7 +37,7 @@ export class IngredientDtoService
   }
 
   getAll(uid: string): Observable<IngredientDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(

--- a/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-type-dto.service.ts
+++ b/libs/menu-matriarch/ingredients/data-access/src/lib/internal/ingredient-type-dto.service.ts
@@ -34,7 +34,7 @@ export class IngredientTypeDtoService
   }
 
   getAll(uid: string): Observable<IngredientTypeDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(

--- a/libs/menu-matriarch/meals/data-access/src/lib/internal/meal-dto.service.ts
+++ b/libs/menu-matriarch/meals/data-access/src/lib/internal/meal-dto.service.ts
@@ -35,7 +35,7 @@ export class MealDtoService implements IDtoService<Meal, MealDto> {
   }
 
   getAll(uid: string): Observable<MealDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(uid: string, meal: EditableMealData): Promise<string> {

--- a/libs/menu-matriarch/menus/data-access/src/lib/internal/menu-dto.service.ts
+++ b/libs/menu-matriarch/menus/data-access/src/lib/internal/menu-dto.service.ts
@@ -32,7 +32,7 @@ export class MenuDtoService implements IDtoService<Menu, MenuDto> {
   }
 
   getAll(uid: string): Observable<MenuDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(uid: string, menu: EditableMenuData): Promise<string> {

--- a/libs/menu-matriarch/tags/data-access/src/lib/internal/tag-dto.service.ts
+++ b/libs/menu-matriarch/tags/data-access/src/lib/internal/tag-dto.service.ts
@@ -32,7 +32,7 @@ export class TagDtoService implements IDtoService<Tag, TagDto> {
   }
 
   getAll(uid: string): Observable<TagDto[]> {
-    return this._dtoService.getMany(this._endpoint, uid);
+    return this._dtoService.getAll(this._endpoint, uid);
   }
 
   async create(uid: string, tag: EditableTagData): Promise<string> {


### PR DESCRIPTION
Completes what the most recently [merged PR](https://github.com/johnnycopes/atocha/pull/498) started by finishing the rename of all relevant methods