### PR TITLE
Moves bootstrapping logic to `APP_INITIALIZER`

### DIFF
--- a/apps/globetrotter/src/app/app.component.ts
+++ b/apps/globetrotter/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 import {
   ErrorService,
   LoaderService,
+  PlaceService,
 } from '@atocha/globetrotter/shared/data-access';
 import {
   ErrorComponent,
@@ -18,12 +19,17 @@ import {
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   loading$ = this._loaderService.global$;
   error$ = this._errorService.global$;
 
   constructor(
     private _loaderService: LoaderService,
-    private _errorService: ErrorService
+    private _errorService: ErrorService,
+    private _placeService: PlaceService
   ) {}
+
+  ngOnInit(): void {
+    this._placeService.init();
+  }
 }

--- a/apps/globetrotter/src/app/app.component.ts
+++ b/apps/globetrotter/src/app/app.component.ts
@@ -1,11 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 import {
   ErrorService,
   LoaderService,
-  PlaceService,
 } from '@atocha/globetrotter/shared/data-access';
 import {
   ErrorComponent,
@@ -19,17 +18,12 @@ import {
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   loading$ = this._loaderService.global$;
   error$ = this._errorService.global$;
 
   constructor(
     private _loaderService: LoaderService,
-    private _errorService: ErrorService,
-    private _placeService: PlaceService
+    private _errorService: ErrorService
   ) {}
-
-  ngOnInit(): void {
-    this._placeService.init();
-  }
 }

--- a/apps/globetrotter/src/app/app.config.ts
+++ b/apps/globetrotter/src/app/app.config.ts
@@ -19,7 +19,8 @@ export const appConfig: ApplicationConfig = {
     importProvidersFrom([BrowserAnimationsModule, HttpClientModule]),
     {
       provide: APP_INITIALIZER,
-      useFactory: (placeService: PlaceService) => () => placeService.init(),
+      useFactory: (placeService: PlaceService) => () =>
+        placeService.initialize(),
       deps: [PlaceService],
       multi: true,
     },

--- a/apps/globetrotter/src/app/app.config.ts
+++ b/apps/globetrotter/src/app/app.config.ts
@@ -1,9 +1,14 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  ApplicationConfig,
+  importProvidersFrom,
+} from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { APP_ROUTES } from './app-routes';
+import { PlaceService } from '@atocha/globetrotter/shared/data-access';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -12,5 +17,11 @@ export const appConfig: ApplicationConfig = {
       withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })
     ),
     importProvidersFrom([BrowserAnimationsModule, HttpClientModule]),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (placeService: PlaceService) => () => placeService.init(),
+      deps: [PlaceService],
+      multi: true,
+    },
   ],
 };

--- a/libs/globetrotter/shared/data-access/src/lib/place.service.spec.ts
+++ b/libs/globetrotter/shared/data-access/src/lib/place.service.spec.ts
@@ -41,6 +41,7 @@ describe('PlaceService', () => {
       ],
     });
     service = TestBed.inject(PlaceService);
+    service.initialize();
   });
 
   it('correctly initializes state', (done) => {

--- a/libs/globetrotter/shared/data-access/src/lib/place.service.ts
+++ b/libs/globetrotter/shared/data-access/src/lib/place.service.ts
@@ -28,7 +28,7 @@ export class PlaceService {
     private _loaderService: LoaderService
   ) {}
 
-  init() {
+  initialize() {
     this._loaderService.setGlobalLoader(true);
     this._apiService
       .fetchCountries()

--- a/libs/globetrotter/shared/data-access/src/lib/place.service.ts
+++ b/libs/globetrotter/shared/data-access/src/lib/place.service.ts
@@ -26,7 +26,9 @@ export class PlaceService {
     private _apiService: ApiService,
     private _errorService: ErrorService,
     private _loaderService: LoaderService
-  ) {
+  ) {}
+
+  init() {
     this._loaderService.setGlobalLoader(true);
     this._apiService
       .fetchCountries()


### PR DESCRIPTION
After the previous PR, there were some issues with the initial data fetching logic happening too late in the application bootstrapping process. This PR extracts the `PlaceService` constructor logic into an `initialize` method and explicitly calls it in an APP_INITIALIZER method to ensure it gets called from the very beginning of the process.