### PR TITLE
Fixes flag container bug

### DIFF
--- a/libs/globetrotter/shared/ui/src/lib/flag/flag.component.ts
+++ b/libs/globetrotter/shared/ui/src/lib/flag/flag.component.ts
@@ -8,6 +8,11 @@ import { Component, Input } from '@angular/core';
   template: `<img class="flag" [src]="src" alt="Flag of {{ name }}" />`,
   styles: [
     `
+      :host {
+        display: inline-block;
+        width: 100%;
+      }
+
       .flag {
         max-width: 192px;
         max-height: 128px;


### PR DESCRIPTION
Adds concrete width to `FlagComponent` host element to prevent certain flag images from having a 0px width