### PR TITLE
Updates Umami links

### DIFF
--- a/apps/lorenzo/src/index.html
+++ b/apps/lorenzo/src/index.html
@@ -19,8 +19,8 @@
       </svg>"
     />
     <script
-      async
-      src="https://analytics.eu.umami.is/script.js"
+      defer
+      src="https://cloud.umami.is/script.js"
       data-website-id="d50702c6-2535-4b0a-8156-93a8485a2fcd"
     ></script>
   </head>

--- a/apps/spirit-islander/src/index.html
+++ b/apps/spirit-islander/src/index.html
@@ -23,8 +23,8 @@
       </svg>"
     />
     <script
-      async
-      src="https://analytics.eu.umami.is/script.js"
+      defer
+      src="https://cloud.umami.is/script.js"
       data-website-id="a0f13c12-2fe1-4c19-a439-27e0485dc1dd"
     ></script>
   </head>


### PR DESCRIPTION
The new links use `defer` instead of `async` and point to new URLs