### PR TITLE
Globetrotter SCSS upgrade

### DIFF
--- a/apps/globetrotter/src/scss/_main.scss
+++ b/apps/globetrotter/src/scss/_main.scss
@@ -1,5 +1,0 @@
-@forward 'typography';
-@forward 'colors';
-@forward 'layout';
-@forward 'animations';
-@forward 'mixins';

--- a/apps/globetrotter/src/scss/_main.scss
+++ b/apps/globetrotter/src/scss/_main.scss
@@ -1,0 +1,5 @@
+@forward 'typography';
+@forward 'colors';
+@forward 'layout';
+@forward 'animations';
+@forward 'mixins';

--- a/apps/globetrotter/src/scss/_mixins.scss
+++ b/apps/globetrotter/src/scss/_mixins.scss
@@ -1,6 +1,4 @@
 @use 'sass:map';
-@use 'colors';
-@use 'layout';
 
 $breakpoints: (
   all: 0px,
@@ -29,18 +27,18 @@ $breakpoints: (
 
 @mixin custom-scrollbar {
   &::-webkit-scrollbar-track {
-    background-color: map.get(colors.$color, darkest);
-    border-radius: map.get(layout.$border, radius);
+    background-color: map.get($color, darkest);
+    border-radius: map.get($border, radius);
   }
 
   &::-webkit-scrollbar {
     width: 10px;
-    background-color: map.get(colors.$color, darkest);
-    border-radius: map.get(layout.$border, radius);
+    background-color: map.get($color, darkest);
+    border-radius: map.get($border, radius);
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: map.get(colors.$color, medium-dark);
-    border-radius: map.get(layout.$border, radius);
+    background-color: map.get($color, medium-dark);
+    border-radius: map.get($border, radius);
   }
 }

--- a/apps/globetrotter/src/scss/_mixins.scss
+++ b/apps/globetrotter/src/scss/_mixins.scss
@@ -1,4 +1,6 @@
 @use 'sass:map';
+@use 'colors';
+@use 'layout';
 
 $breakpoints: (
   all: 0px,
@@ -27,18 +29,18 @@ $breakpoints: (
 
 @mixin custom-scrollbar {
   &::-webkit-scrollbar-track {
-    background-color: map.get($color, darkest);
-    border-radius: map.get($border, radius);
+    background-color: map.get(colors.$color, darkest);
+    border-radius: map.get(layout.$border, radius);
   }
 
   &::-webkit-scrollbar {
     width: 10px;
-    background-color: map.get($color, darkest);
-    border-radius: map.get($border, radius);
+    background-color: map.get(colors.$color, darkest);
+    border-radius: map.get(layout.$border, radius);
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: map.get($color, medium-dark);
-    border-radius: map.get($border, radius);
+    background-color: map.get(colors.$color, medium-dark);
+    border-radius: map.get(layout.$border, radius);
   }
 }

--- a/apps/globetrotter/src/scss/modules.scss
+++ b/apps/globetrotter/src/scss/modules.scss
@@ -1,0 +1,5 @@
+@forward 'animations';
+@forward 'colors';
+@forward 'layout';
+@forward 'mixins';
+@forward 'typography';

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use 'modules';
-@forward 'modules';
 
 *,
 *::before,

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,9 +1,6 @@
 @use 'sass:map';
-@import 'typography';
-@import 'colors';
-@import 'layout';
-@import 'animations';
-@import 'mixins';
+@use 'modules';
+@forward 'modules';
 
 *,
 *::before,
@@ -17,17 +14,17 @@ body {
 }
 
 body {
-  color: map.get($color, lightest);
-  background: map.get($color, darkest);
-  font-family: $font-stack;
-  font-size: map.get($font-size, 20);
-  font-weight: map.get($font-weight, normal);
-  line-height: map.get($line-height, small);
+  color: map.get(modules.$color, lightest);
+  background: map.get(modules.$color, darkest);
+  font-family: modules.$font-stack;
+  font-size: map.get(modules.$font-size, 20);
+  font-weight: map.get(modules.$font-weight, normal);
+  line-height: map.get(modules.$line-height, small);
   position: relative;
-  @include custom-scrollbar;
+  @include modules.custom-scrollbar;
 
-  @include tablet {
-    font-size: map.get($font-size, 24);
+  @include modules.tablet {
+    font-size: map.get(modules.$font-size, 24);
   }
 }
 
@@ -38,74 +35,74 @@ sup {
 }
 
 .bold {
-  font-weight: map.get($font-weight, bold);
+  font-weight: map.get(modules.$font-weight, bold);
 }
 
 .small-caps {
-  margin-bottom: map.get($spacing, 8);
-  font-size: map.get($font-size, 16);
-  font-weight: map.get($font-weight, bold);
+  margin-bottom: map.get(modules.$spacing, 8);
+  font-size: map.get(modules.$font-size, 16);
+  font-weight: map.get(modules.$font-weight, bold);
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: map.get($color, medium);
+  color: map.get(modules.$color, medium);
 }
 
 // Component styling overrides
 
 app-root {
   .core-button {
-    padding: map.get($spacing, 2) 0;
-    width: map.get($spacing, 128);
-    color: map.get($color, darkest);
-    background: map.get($color, lightest);
-    font-family: $font-stack;
-    font-size: map.get($font-size, 20);
-    border: map.get($border, thin) solid map.get($color, lightest);
-    border-radius: map.get($border, radius);
+    padding: map.get(modules.$spacing, 2) 0;
+    width: map.get(modules.$spacing, 128);
+    color: map.get(modules.$color, darkest);
+    background: map.get(modules.$color, lightest);
+    font-family: modules.$font-stack;
+    font-size: map.get(modules.$font-size, 20);
+    border: map.get(modules.$border, thin) solid map.get(modules.$color, lightest);
+    border-radius: map.get(modules.$border, radius);
 
     &--primary {
-      color: map.get($color, darkest);
-      background: map.get($color, lightest);
+      color: map.get(modules.$color, darkest);
+      background: map.get(modules.$color, lightest);
 
       &:hover {
-        background: lighten(map.get($color, lightest), 10%);
+        background: lighten(map.get(modules.$color, lightest), 10%);
       }
 
       &:disabled {
-        background: map.get($color, medium);
+        background: map.get(modules.$color, medium);
       }
     }
 
     &--secondary {
-      color: map.get($color, lightest);
+      color: map.get(modules.$color, lightest);
       background: transparent;
 
       &:hover {
-        background: lighten(map.get($color, darkest), 10%);
+        background: lighten(map.get(modules.$color, darkest), 10%);
       }
 
       &:disabled {
-        color: map.get($color, medium);
+        color: map.get(modules.$color, medium);
       }
     }
 
     &:disabled {
-      border-color: map.get($color, medium);
+      border-color: map.get(modules.$color, medium);
     }
   }
 
   .core-checkbox {
-    --checkbox-color-hover: #{map.get($color, medium)};
-    --label-margin: #{map.get($spacing, 12)};
-    --checkbox-border: #{map.get($color, lightest)};
-    --checkmark-color: #{map.get($color, lightest)};
+    --checkbox-color-hover: #{map.get(modules.$color, medium)};
+    --label-margin: #{map.get(modules.$spacing, 12)};
+    --checkbox-border: #{map.get(modules.$color, lightest)};
+    --checkmark-color: #{map.get(modules.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox--checked,
   [data-level='1'] > .core-checkbox--indeterminate {
-    --checkbox-border: #{map.get($color, lightest)};
-    --checkmark-color: #{map.get($color, darkest)};
-    --checkbox-color: #{map.get($color, lightest)};
+    --checkbox-border: #{map.get(modules.$color, lightest)};
+    --checkmark-color: #{map.get(modules.$color, darkest)};
+    --checkbox-color: #{map.get(modules.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox > .core-checkbox__container {
@@ -113,19 +110,19 @@ app-root {
   }
 
   .core-checkbox--unchecked {
-    --checkbox-border: #{map.get($color, medium)};
-    --checkmark-color: #{map.get($color, medium)};
-    color: map.get($color, medium);
+    --checkbox-border: #{map.get(modules.$color, medium)};
+    --checkmark-color: #{map.get(modules.$color, medium)};
+    color: map.get(modules.$color, medium);
   }
 
   .core-search-input {
     &__field {
-      padding-right: map.get($spacing, 32);
+      padding-right: map.get(modules.$spacing, 32);
     }
 
     &__clear {
-      width: map.get($spacing, 32);
-      color: map.get($color, medium);
+      width: map.get(modules.$spacing, 32);
+      color: map.get(modules.$color, medium);
     }
   }
 }

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'modules';
+@use 'modules' as styles;
 
 *,
 *::before,
@@ -13,17 +13,17 @@ body {
 }
 
 body {
-  color: map.get(modules.$color, lightest);
-  background: map.get(modules.$color, darkest);
-  font-family: modules.$font-stack;
-  font-size: map.get(modules.$font-size, 20);
-  font-weight: map.get(modules.$font-weight, normal);
-  line-height: map.get(modules.$line-height, small);
+  color: map.get(styles.$color, lightest);
+  background: map.get(styles.$color, darkest);
+  font-family: styles.$font-stack;
+  font-size: map.get(styles.$font-size, 20);
+  font-weight: map.get(styles.$font-weight, normal);
+  line-height: map.get(styles.$line-height, small);
   position: relative;
-  @include modules.custom-scrollbar;
+  @include styles.custom-scrollbar;
 
-  @include modules.tablet {
-    font-size: map.get(modules.$font-size, 24);
+  @include styles.tablet {
+    font-size: map.get(styles.$font-size, 24);
   }
 }
 
@@ -34,74 +34,74 @@ sup {
 }
 
 .bold {
-  font-weight: map.get(modules.$font-weight, bold);
+  font-weight: map.get(styles.$font-weight, bold);
 }
 
 .small-caps {
-  margin-bottom: map.get(modules.$spacing, 8);
-  font-size: map.get(modules.$font-size, 16);
-  font-weight: map.get(modules.$font-weight, bold);
+  margin-bottom: map.get(styles.$spacing, 8);
+  font-size: map.get(styles.$font-size, 16);
+  font-weight: map.get(styles.$font-weight, bold);
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: map.get(modules.$color, medium);
+  color: map.get(styles.$color, medium);
 }
 
 // Component styling overrides
 
 app-root {
   .core-button {
-    padding: map.get(modules.$spacing, 2) 0;
-    width: map.get(modules.$spacing, 128);
-    color: map.get(modules.$color, darkest);
-    background: map.get(modules.$color, lightest);
-    font-family: modules.$font-stack;
-    font-size: map.get(modules.$font-size, 20);
-    border: map.get(modules.$border, thin) solid map.get(modules.$color, lightest);
-    border-radius: map.get(modules.$border, radius);
+    padding: map.get(styles.$spacing, 2) 0;
+    width: map.get(styles.$spacing, 128);
+    color: map.get(styles.$color, darkest);
+    background: map.get(styles.$color, lightest);
+    font-family: styles.$font-stack;
+    font-size: map.get(styles.$font-size, 20);
+    border: map.get(styles.$border, thin) solid map.get(styles.$color, lightest);
+    border-radius: map.get(styles.$border, radius);
 
     &--primary {
-      color: map.get(modules.$color, darkest);
-      background: map.get(modules.$color, lightest);
+      color: map.get(styles.$color, darkest);
+      background: map.get(styles.$color, lightest);
 
       &:hover {
-        background: lighten(map.get(modules.$color, lightest), 10%);
+        background: lighten(map.get(styles.$color, lightest), 10%);
       }
 
       &:disabled {
-        background: map.get(modules.$color, medium);
+        background: map.get(styles.$color, medium);
       }
     }
 
     &--secondary {
-      color: map.get(modules.$color, lightest);
+      color: map.get(styles.$color, lightest);
       background: transparent;
 
       &:hover {
-        background: lighten(map.get(modules.$color, darkest), 10%);
+        background: lighten(map.get(styles.$color, darkest), 10%);
       }
 
       &:disabled {
-        color: map.get(modules.$color, medium);
+        color: map.get(styles.$color, medium);
       }
     }
 
     &:disabled {
-      border-color: map.get(modules.$color, medium);
+      border-color: map.get(styles.$color, medium);
     }
   }
 
   .core-checkbox {
-    --checkbox-color-hover: #{map.get(modules.$color, medium)};
-    --label-margin: #{map.get(modules.$spacing, 12)};
-    --checkbox-border: #{map.get(modules.$color, lightest)};
-    --checkmark-color: #{map.get(modules.$color, lightest)};
+    --checkbox-color-hover: #{map.get(styles.$color, medium)};
+    --label-margin: #{map.get(styles.$spacing, 12)};
+    --checkbox-border: #{map.get(styles.$color, lightest)};
+    --checkmark-color: #{map.get(styles.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox--checked,
   [data-level='1'] > .core-checkbox--indeterminate {
-    --checkbox-border: #{map.get(modules.$color, lightest)};
-    --checkmark-color: #{map.get(modules.$color, darkest)};
-    --checkbox-color: #{map.get(modules.$color, lightest)};
+    --checkbox-border: #{map.get(styles.$color, lightest)};
+    --checkmark-color: #{map.get(styles.$color, darkest)};
+    --checkbox-color: #{map.get(styles.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox > .core-checkbox__container {
@@ -109,19 +109,19 @@ app-root {
   }
 
   .core-checkbox--unchecked {
-    --checkbox-border: #{map.get(modules.$color, medium)};
-    --checkmark-color: #{map.get(modules.$color, medium)};
-    color: map.get(modules.$color, medium);
+    --checkbox-border: #{map.get(styles.$color, medium)};
+    --checkmark-color: #{map.get(styles.$color, medium)};
+    color: map.get(styles.$color, medium);
   }
 
   .core-search-input {
     &__field {
-      padding-right: map.get(modules.$spacing, 32);
+      padding-right: map.get(styles.$spacing, 32);
     }
 
     &__clear {
-      width: map.get(modules.$spacing, 32);
-      color: map.get(modules.$color, medium);
+      width: map.get(styles.$spacing, 32);
+      color: map.get(styles.$color, medium);
     }
   }
 }

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use 'modules' as styles;
 
+
 *,
 *::before,
 *::after {
@@ -64,7 +65,7 @@ app-root {
       background: map.get(styles.$color, lightest);
 
       &:hover {
-        background: lighten(map.get(styles.$color, lightest), 10%);
+        background: map.get(styles.$color, white);
       }
 
       &:disabled {
@@ -77,7 +78,7 @@ app-root {
       background: transparent;
 
       &:hover {
-        background: lighten(map.get(styles.$color, darkest), 10%);
+        background: map.get(styles.$color, dark);
       }
 
       &:disabled {

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,7 +1,6 @@
 @use 'sass:map';
 @use 'modules' as styles;
 
-
 *,
 *::before,
 *::after {

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,9 +1,6 @@
 @use 'sass:map';
-@import 'typography';
-@import 'colors';
-@import 'layout';
-@import 'animations';
-@import 'mixins';
+@use 'main';
+@forward 'main';
 
 *,
 *::before,
@@ -17,17 +14,17 @@ body {
 }
 
 body {
-  color: map.get($color, lightest);
-  background: map.get($color, darkest);
-  font-family: $font-stack;
-  font-size: map.get($font-size, 20);
-  font-weight: map.get($font-weight, normal);
-  line-height: map.get($line-height, small);
+  color: map.get(main.$color, lightest);
+  background: map.get(main.$color, darkest);
+  font-family: main.$font-stack;
+  font-size: map.get(main.$font-size, 20);
+  font-weight: map.get(main.$font-weight, normal);
+  line-height: map.get(main.$line-height, small);
   position: relative;
-  @include custom-scrollbar;
+  @include main.custom-scrollbar;
 
-  @include tablet {
-    font-size: map.get($font-size, 24);
+  @include main.tablet {
+    font-size: map.get(main.$font-size, 24);
   }
 }
 
@@ -38,74 +35,74 @@ sup {
 }
 
 .bold {
-  font-weight: map.get($font-weight, bold);
+  font-weight: map.get(main.$font-weight, bold);
 }
 
 .small-caps {
-  margin-bottom: map.get($spacing, 8);
-  font-size: map.get($font-size, 16);
-  font-weight: map.get($font-weight, bold);
+  margin-bottom: map.get(main.$spacing, 8);
+  font-size: map.get(main.$font-size, 16);
+  font-weight: map.get(main.$font-weight, bold);
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: map.get($color, medium);
+  color: map.get(main.$color, medium);
 }
 
 // Component styling overrides
 
 app-root {
   .core-button {
-    padding: map.get($spacing, 2) 0;
-    width: map.get($spacing, 128);
-    color: map.get($color, darkest);
-    background: map.get($color, lightest);
-    font-family: $font-stack;
-    font-size: map.get($font-size, 20);
-    border: map.get($border, thin) solid map.get($color, lightest);
-    border-radius: map.get($border, radius);
+    padding: map.get(main.$spacing, 2) 0;
+    width: map.get(main.$spacing, 128);
+    color: map.get(main.$color, darkest);
+    background: map.get(main.$color, lightest);
+    font-family: main.$font-stack;
+    font-size: map.get(main.$font-size, 20);
+    border: map.get(main.$border, thin) solid map.get(main.$color, lightest);
+    border-radius: map.get(main.$border, radius);
 
     &--primary {
-      color: map.get($color, darkest);
-      background: map.get($color, lightest);
+      color: map.get(main.$color, darkest);
+      background: map.get(main.$color, lightest);
 
       &:hover {
-        background: lighten(map.get($color, lightest), 10%);
+        background: lighten(map.get(main.$color, lightest), 10%);
       }
 
       &:disabled {
-        background: map.get($color, medium);
+        background: map.get(main.$color, medium);
       }
     }
 
     &--secondary {
-      color: map.get($color, lightest);
+      color: map.get(main.$color, lightest);
       background: transparent;
 
       &:hover {
-        background: lighten(map.get($color, darkest), 10%);
+        background: lighten(map.get(main.$color, darkest), 10%);
       }
 
       &:disabled {
-        color: map.get($color, medium);
+        color: map.get(main.$color, medium);
       }
     }
 
     &:disabled {
-      border-color: map.get($color, medium);
+      border-color: map.get(main.$color, medium);
     }
   }
 
   .core-checkbox {
-    --checkbox-color-hover: #{map.get($color, medium)};
-    --label-margin: #{map.get($spacing, 12)};
-    --checkbox-border: #{map.get($color, lightest)};
-    --checkmark-color: #{map.get($color, lightest)};
+    --checkbox-color-hover: #{map.get(main.$color, medium)};
+    --label-margin: #{map.get(main.$spacing, 12)};
+    --checkbox-border: #{map.get(main.$color, lightest)};
+    --checkmark-color: #{map.get(main.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox--checked,
   [data-level='1'] > .core-checkbox--indeterminate {
-    --checkbox-border: #{map.get($color, lightest)};
-    --checkmark-color: #{map.get($color, darkest)};
-    --checkbox-color: #{map.get($color, lightest)};
+    --checkbox-border: #{map.get(main.$color, lightest)};
+    --checkmark-color: #{map.get(main.$color, darkest)};
+    --checkbox-color: #{map.get(main.$color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox > .core-checkbox__container {
@@ -113,19 +110,19 @@ app-root {
   }
 
   .core-checkbox--unchecked {
-    --checkbox-border: #{map.get($color, medium)};
-    --checkmark-color: #{map.get($color, medium)};
-    color: map.get($color, medium);
+    --checkbox-border: #{map.get(main.$color, medium)};
+    --checkmark-color: #{map.get(main.$color, medium)};
+    color: map.get(main.$color, medium);
   }
 
   .core-search-input {
     &__field {
-      padding-right: map.get($spacing, 32);
+      padding-right: map.get(main.$spacing, 32);
     }
 
     &__clear {
-      width: map.get($spacing, 32);
-      color: map.get($color, medium);
+      width: map.get(main.$spacing, 32);
+      color: map.get(main.$color, medium);
     }
   }
 }

--- a/apps/globetrotter/src/scss/styles.scss
+++ b/apps/globetrotter/src/scss/styles.scss
@@ -1,6 +1,9 @@
 @use 'sass:map';
-@use 'main';
-@forward 'main';
+@import 'typography';
+@import 'colors';
+@import 'layout';
+@import 'animations';
+@import 'mixins';
 
 *,
 *::before,
@@ -14,17 +17,17 @@ body {
 }
 
 body {
-  color: map.get(main.$color, lightest);
-  background: map.get(main.$color, darkest);
-  font-family: main.$font-stack;
-  font-size: map.get(main.$font-size, 20);
-  font-weight: map.get(main.$font-weight, normal);
-  line-height: map.get(main.$line-height, small);
+  color: map.get($color, lightest);
+  background: map.get($color, darkest);
+  font-family: $font-stack;
+  font-size: map.get($font-size, 20);
+  font-weight: map.get($font-weight, normal);
+  line-height: map.get($line-height, small);
   position: relative;
-  @include main.custom-scrollbar;
+  @include custom-scrollbar;
 
-  @include main.tablet {
-    font-size: map.get(main.$font-size, 24);
+  @include tablet {
+    font-size: map.get($font-size, 24);
   }
 }
 
@@ -35,74 +38,74 @@ sup {
 }
 
 .bold {
-  font-weight: map.get(main.$font-weight, bold);
+  font-weight: map.get($font-weight, bold);
 }
 
 .small-caps {
-  margin-bottom: map.get(main.$spacing, 8);
-  font-size: map.get(main.$font-size, 16);
-  font-weight: map.get(main.$font-weight, bold);
+  margin-bottom: map.get($spacing, 8);
+  font-size: map.get($font-size, 16);
+  font-weight: map.get($font-weight, bold);
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: map.get(main.$color, medium);
+  color: map.get($color, medium);
 }
 
 // Component styling overrides
 
 app-root {
   .core-button {
-    padding: map.get(main.$spacing, 2) 0;
-    width: map.get(main.$spacing, 128);
-    color: map.get(main.$color, darkest);
-    background: map.get(main.$color, lightest);
-    font-family: main.$font-stack;
-    font-size: map.get(main.$font-size, 20);
-    border: map.get(main.$border, thin) solid map.get(main.$color, lightest);
-    border-radius: map.get(main.$border, radius);
+    padding: map.get($spacing, 2) 0;
+    width: map.get($spacing, 128);
+    color: map.get($color, darkest);
+    background: map.get($color, lightest);
+    font-family: $font-stack;
+    font-size: map.get($font-size, 20);
+    border: map.get($border, thin) solid map.get($color, lightest);
+    border-radius: map.get($border, radius);
 
     &--primary {
-      color: map.get(main.$color, darkest);
-      background: map.get(main.$color, lightest);
+      color: map.get($color, darkest);
+      background: map.get($color, lightest);
 
       &:hover {
-        background: lighten(map.get(main.$color, lightest), 10%);
+        background: lighten(map.get($color, lightest), 10%);
       }
 
       &:disabled {
-        background: map.get(main.$color, medium);
+        background: map.get($color, medium);
       }
     }
 
     &--secondary {
-      color: map.get(main.$color, lightest);
+      color: map.get($color, lightest);
       background: transparent;
 
       &:hover {
-        background: lighten(map.get(main.$color, darkest), 10%);
+        background: lighten(map.get($color, darkest), 10%);
       }
 
       &:disabled {
-        color: map.get(main.$color, medium);
+        color: map.get($color, medium);
       }
     }
 
     &:disabled {
-      border-color: map.get(main.$color, medium);
+      border-color: map.get($color, medium);
     }
   }
 
   .core-checkbox {
-    --checkbox-color-hover: #{map.get(main.$color, medium)};
-    --label-margin: #{map.get(main.$spacing, 12)};
-    --checkbox-border: #{map.get(main.$color, lightest)};
-    --checkmark-color: #{map.get(main.$color, lightest)};
+    --checkbox-color-hover: #{map.get($color, medium)};
+    --label-margin: #{map.get($spacing, 12)};
+    --checkbox-border: #{map.get($color, lightest)};
+    --checkmark-color: #{map.get($color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox--checked,
   [data-level='1'] > .core-checkbox--indeterminate {
-    --checkbox-border: #{map.get(main.$color, lightest)};
-    --checkmark-color: #{map.get(main.$color, darkest)};
-    --checkbox-color: #{map.get(main.$color, lightest)};
+    --checkbox-border: #{map.get($color, lightest)};
+    --checkmark-color: #{map.get($color, darkest)};
+    --checkbox-color: #{map.get($color, lightest)};
   }
 
   [data-level='1'] > .core-checkbox > .core-checkbox__container {
@@ -110,19 +113,19 @@ app-root {
   }
 
   .core-checkbox--unchecked {
-    --checkbox-border: #{map.get(main.$color, medium)};
-    --checkmark-color: #{map.get(main.$color, medium)};
-    color: map.get(main.$color, medium);
+    --checkbox-border: #{map.get($color, medium)};
+    --checkmark-color: #{map.get($color, medium)};
+    color: map.get($color, medium);
   }
 
   .core-search-input {
     &__field {
-      padding-right: map.get(main.$spacing, 32);
+      padding-right: map.get($spacing, 32);
     }
 
     &__clear {
-      width: map.get(main.$spacing, 32);
-      color: map.get(main.$color, medium);
+      width: map.get($spacing, 32);
+      color: map.get($color, medium);
     }
   }
 }

--- a/libs/globetrotter/explore/feature/src/lib/explore-countries/explore-countries.component.scss
+++ b/libs/globetrotter/explore/feature/src/lib/explore-countries/explore-countries.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .list {
   margin-top: map.get(styles.$spacing, 12);

--- a/libs/globetrotter/explore/feature/src/lib/explore-country/explore-country.component.scss
+++ b/libs/globetrotter/explore/feature/src/lib/explore-country/explore-country.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .top {
   display: flex;

--- a/libs/globetrotter/explore/feature/src/lib/explore.component.scss
+++ b/libs/globetrotter/explore/feature/src/lib/explore.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   display: block;

--- a/libs/globetrotter/learn/feature/src/lib/quiz/quiz-cards/quiz-card/quiz-card.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/quiz/quiz-cards/quiz-card/quiz-card.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .quiz-card {
   &__name {

--- a/libs/globetrotter/learn/feature/src/lib/quiz/quiz-cards/quiz-cards.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/quiz/quiz-cards/quiz-cards.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .quiz-cards {
   display: grid;

--- a/libs/globetrotter/learn/feature/src/lib/quiz/quiz-menu/quiz-menu.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/quiz/quiz-menu/quiz-menu.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 $padding: map.get(styles.$app, wrapper-padding);
 

--- a/libs/globetrotter/learn/feature/src/lib/select/select-places/select-places.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/select/select-places/select-places.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .form {
   display: grid;

--- a/libs/globetrotter/learn/feature/src/lib/select/select-quantity/select-quantity.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/select/select-quantity/select-quantity.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   display: flex;

--- a/libs/globetrotter/learn/feature/src/lib/select/select-type/select-type.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/select/select-type/select-type.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .container {
   display: flex;

--- a/libs/globetrotter/learn/feature/src/lib/select/select.component.scss
+++ b/libs/globetrotter/learn/feature/src/lib/select/select.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .wrapper {
   max-width: map.get(styles.$learn, max-width);

--- a/libs/globetrotter/learn/ui/src/lib/errors/errors.component.scss
+++ b/libs/globetrotter/learn/ui/src/lib/errors/errors.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .message {
   padding: map.get(styles.$spacing, 4);

--- a/libs/globetrotter/learn/ui/src/lib/fixed-slideable-panel/fixed-slideable-panel.component.scss
+++ b/libs/globetrotter/learn/ui/src/lib/fixed-slideable-panel/fixed-slideable-panel.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 $height: map.get(styles.$app, header-height);
 

--- a/libs/globetrotter/learn/ui/src/lib/flip-card/flip-card.component.scss
+++ b/libs/globetrotter/learn/ui/src/lib/flip-card/flip-card.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   perspective: 800px;

--- a/libs/globetrotter/shared/ui/src/lib/error/error.component.scss
+++ b/libs/globetrotter/shared/ui/src/lib/error/error.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   height: 100%;

--- a/libs/globetrotter/shared/ui/src/lib/icon/icon.component.scss
+++ b/libs/globetrotter/shared/ui/src/lib/icon/icon.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   display: inline-block;

--- a/libs/globetrotter/shared/ui/src/lib/input/input.component.scss
+++ b/libs/globetrotter/shared/ui/src/lib/input/input.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   display: flex;

--- a/libs/globetrotter/shared/ui/src/lib/loader/loader.component.scss
+++ b/libs/globetrotter/shared/ui/src/lib/loader/loader.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   height: 100%;

--- a/libs/globetrotter/shell/feature/src/lib/home/home.component.scss
+++ b/libs/globetrotter/shell/feature/src/lib/home/home.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .home {
   display: flex;

--- a/libs/globetrotter/shell/feature/src/lib/navigation/navigation.component.scss
+++ b/libs/globetrotter/shell/feature/src/lib/navigation/navigation.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 .navigation {
   display: flex;

--- a/libs/globetrotter/shell/feature/src/lib/shell/shell.component.scss
+++ b/libs/globetrotter/shell/feature/src/lib/shell/shell.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'styles' as styles;
+@use 'modules' as styles;
 
 :host {
   display: block;


### PR DESCRIPTION
Resolves https://github.com/johnnycopes/atocha/issues/562

1. Centralizes all partials (now modules) in new `modules.scss` file
2. Imports the `modules` module across the webapp (namespace remains as the existing `styles` keyword)
3. Replaces use of deprecated `lighten` function